### PR TITLE
Fix compilation with C++11 and above

### DIFF
--- a/xs/src/libslic3r/ExPolygon.hpp
+++ b/xs/src/libslic3r/ExPolygon.hpp
@@ -104,12 +104,12 @@ inline void polygons_append(Polygons &dst, const ExPolygons &src)
 }
 
 #if SLIC3R_CPPVER >= 11
-inline void polygons_append(Polygons &dst, ExPolygons &&src) 
+inline void polygons_append(Polygons &dst, ExPolygons &&src)
 { 
     dst.reserve(dst.size() + number_polygons(src));
-    for (ExPolygons::const_iterator it = expolys.begin(); it != expolys.end(); ++ it) {
+    for (ExPolygons::const_iterator it = src.begin(); it != src.end(); ++ it) {
         dst.push_back(std::move(it->contour));
-        std::move(std::begin(it->contour), std::end(it->contour), std::back_inserter(dst));
+        std::move(std::begin(it->holes), std::end(it->holes), std::back_inserter(dst));
     }
 }
 #endif

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -162,7 +162,11 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
             continue;
         
         // get filler object
+#if SLIC3R_CPPVER >= 11
+        std::unique_ptr<Fill> f = std::unique_ptr<Fill>(Fill::new_from_type(fill_pattern));
+#else
         std::auto_ptr<Fill> f = std::auto_ptr<Fill>(Fill::new_from_type(fill_pattern));
+#endif
         f->set_bounding_box(layerm.layer()->object()->bounding_box());
         
         // calculate the actual flow we'll be using for this infill

--- a/xs/src/libslic3r/PolylineCollection.hpp
+++ b/xs/src/libslic3r/PolylineCollection.hpp
@@ -8,11 +8,20 @@ namespace Slic3r {
 
 class PolylineCollection
 {
+    static Polylines _chained_path_from(
+        const Polylines &src,
+        Point start_near,
+        bool no_reverse
+#if SLIC3R_CPPVER >= 11
+        , bool move_from_src
+#endif
+    );
+
 public:
     Polylines polylines;
     void chained_path(PolylineCollection* retval, bool no_reverse = false) const
     	{ retval->polylines = chained_path(this->polylines, no_reverse); }
-    void chained_path_from(Point start_near, PolylineCollection* retval, bool no_reverse = false) const 
+    void chained_path_from(Point start_near, PolylineCollection* retval, bool no_reverse = false) const
     	{ retval->polylines = chained_path_from(this->polylines, start_near, no_reverse); }
     Point leftmost_point() const
     	{ return leftmost_point(polylines); }
@@ -22,12 +31,9 @@ public:
 #if SLIC3R_CPPVER >= 11
 	static Polylines chained_path(Polylines &&src, bool no_reverse = false);
 	static Polylines chained_path_from(Polylines &&src, Point start_near, bool no_reverse = false);
-	static Polylines chained_path(Polylines src, bool no_reverse = false);
-	static Polylines chained_path_from(Polylines src, Point start_near, bool no_reverse = false);
-#else
-	static Polylines chained_path(const Polylines &src, bool no_reverse = false);
-	static Polylines chained_path_from(const Polylines &src, Point start_near, bool no_reverse = false);
 #endif
+    static Polylines chained_path(const Polylines &src, bool no_reverse = false);
+    static Polylines chained_path_from(const Polylines &src, Point start_near, bool no_reverse = false);
 };
 
 }

--- a/xs/src/libslic3r/SupportMaterial.cpp
+++ b/xs/src/libslic3r/SupportMaterial.cpp
@@ -1171,8 +1171,13 @@ void PrintObjectSupportMaterial::generate_toolpaths(
         infill_pattern = ipHoneycomb;
         break;
     }
+#if SLIC3R_CPPVER >= 11
+    std::unique_ptr<Fill> filler_interface = std::unique_ptr<Fill>(Fill::new_from_type(ipRectilinear));
+    std::unique_ptr<Fill> filler_support   = std::unique_ptr<Fill>(Fill::new_from_type(infill_pattern));
+#else
     std::auto_ptr<Fill> filler_interface = std::auto_ptr<Fill>(Fill::new_from_type(ipRectilinear));
     std::auto_ptr<Fill> filler_support   = std::auto_ptr<Fill>(Fill::new_from_type(infill_pattern));
+#endif
     {
         BoundingBox bbox_object = object.bounding_box();
         filler_interface->set_bounding_box(bbox_object);

--- a/xs/src/libslic3r/Surface.hpp
+++ b/xs/src/libslic3r/Surface.hpp
@@ -99,11 +99,12 @@ inline Polygons to_polygons(const SurfacesPtr &src)
 #if SLIC3R_CPPVER >= 11
 inline Polygons to_polygons(SurfacesPtr &&src)
 {
+    size_t num = 0;
     for (SurfacesPtr::const_iterator it = src.begin(); it != src.end(); ++it)
         num += (*it)->expolygon.holes.size() + 1;
     Polygons polygons;
     polygons.reserve(num);
-    for (ExPolygons::const_iterator it = src.begin(); it != src.end(); ++it) {
+    for (SurfacesPtr::const_iterator it = src.begin(); it != src.end(); ++it) {
         polygons.push_back(std::move((*it)->expolygon.contour));
         for (Polygons::const_iterator ith = (*it)->expolygon.holes.begin(); ith != (*it)->expolygon.holes.end(); ++ith) {
             polygons.push_back(std::move(*ith));
@@ -146,7 +147,7 @@ inline void polygons_append(Polygons &dst, Surfaces &&src)
     dst.reserve(dst.size() + number_polygons(src));
     for (Surfaces::const_iterator it = src.begin(); it != src.end(); ++ it) {
         dst.push_back(std::move(it->expolygon.contour));
-        std::move(std::begin(it->expolygon.contour), std::end(it->expolygon.contour), std::back_inserter(dst));
+        std::move(std::begin(it->expolygon.holes), std::end(it->expolygon.holes), std::back_inserter(dst));
     }
 }
 #endif
@@ -167,7 +168,7 @@ inline void polygons_append(Polygons &dst, SurfacesPtr &&src)
     dst.reserve(dst.size() + number_polygons(src));
     for (SurfacesPtr::const_iterator it = src.begin(); it != src.end(); ++ it) {
         dst.push_back(std::move((*it)->expolygon.contour));
-        std::move(std::begin((*it)->expolygon.contour), std::end((*it)->expolygon.contour), std::back_inserter(dst));
+        std::move(std::begin((*it)->expolygon.holes), std::end((*it)->expolygon.holes), std::back_inserter(dst));
     }
 }
 #endif


### PR DESCRIPTION
There were several problems in the C++11 and above specific code that prevented compilation with `gcc >= 6.1` where C++14 is used as the default standard instead of C++98 (previous `gcc` versions).

In `ExPolygon.cpp` and `Surface.hpp` there are trivial fixes to typos in the C++11 specific code.

In `PolylineCollection` there was an ambiguity between overloaded functions with `Polylines &&src` and `Polylines src` arguments. In such a situation the compiler [can't resolve between those two functions](http://stackoverflow.com/questions/28701039/ambiguous-call-with-overloaded-r-value-reference-function).

My attempt at a solution is to make a new private _chained_path_from functions which allows explicitly specifying whether the `Polyline` objects from the `const Polylines &src` vector can be moved. In the public interface, there are overloads of `chained_path` and `chained_path_from` functions with const lvalue reference (`const Polylines &src`) and rvalue reference (`Polylines &&src`) parameters. These call `_chained_path_from` respectively asking either to move or not to move from `src`. A user of the `PolylineCollection` can trigger the move variant by passing an rvalue reference (using `std::move`).

This solution might need some reviewing as I'm still not entirely comfortable with move semantics. In particular, I'm not sure if there could be some other way to trigger the `std::move` in `_chained_path_from` without specifying it explicitly (i.e. based on whether the input value is `const Polylines &` or `Polylines &&`). Of course one could just do two overloaded variants of `chained_path_from`, but there would be a difference of only one line and that sounds like unnecessary duplication.