### PR TITLE
Fix missing cubic infill line

### DIFF
--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -823,7 +823,7 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
     }
 
     // Intersect a set of euqally spaced vertical lines wiht expolygon.
-    size_t  n_vlines = (bounding_box.max.x - bounding_box.min.x + SCALED_EPSILON) / line_spacing;
+    size_t  n_vlines = (bounding_box.max.x - bounding_box.min.x + SCALED_EPSILON) / line_spacing + 1;
     coord_t x0 = bounding_box.min.x + line_spacing / 2;
 
 #ifdef SLIC3R_DEBUG


### PR DESCRIPTION
I suppose the lines are shifted somehow like `offset -= (layer_z) % spacing` (couldn't find where/how it's done..) and so it will need an extra line sometimes..

Anyways adding 1 extra line fixes the problem. No idea if this has ugly side effects..