### PR TITLE
Update the version

### DIFF
--- a/xs/src/libslic3r/libslic3r.h
+++ b/xs/src/libslic3r/libslic3r.h
@@ -10,7 +10,7 @@
 #include <stdarg.h>
 
 #define SLIC3R_FORK_NAME "Slic3r Prusa Edition"
-#define SLIC3R_VERSION "1.3.0-dev"
+#define SLIC3R_VERSION "1.31.4"
 
 //FIXME This epsilon value is used for many non-related purposes:
 // For a threshold of a squared Euclidean distance,


### PR DESCRIPTION
If this version is not updated, Slic3r shows the old version
in the title bar and status bar and that can be confusing to the user.

Please keep it in sync with the tag.