### PR TITLE
xs/Build.pl fails to find boost libraries

### DIFF
--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -138,8 +138,8 @@ if (!$ENV{SLIC3R_STATIC} && $have_boost) {
         # Try to find the boost system library.
         my @files = glob "$path/${lib_prefix}system*$lib_ext";
         next if !@files;
-    
-        if ($files[0] =~ /${lib_prefix}system([^.]+)$lib_ext$/) {
+
+        if ($files[0] =~ /\Q${lib_prefix}system\E([^.]*)\Q$lib_ext\E$/) {
             # Suffix contains the version number, the build type etc.
             my $suffix = $1;
             # Verify existence of all required boost libraries at $path.


### PR DESCRIPTION
When compiling Slic3r under OSX the boost libraries are not found.

I downloaded and installed boost 1.62.0 and installed them in /usr/local/boost-1.62.0

The build command failed to find the libraries:
```
BOOST_LIBRARYDIR=/usr/local/boost-1.62.0/lib BOOST_INCLUDEDIR=/usr/local/boost-1.62.0/include perl Build.PL --sudo
```

This minor change allows the libraries to be detected.

commit 7fc66514bf3fbcc2c2709a4eb94856fa9b3ba523
Author: Bill Waggoner <ctgreybeard@gmail.com>
Date:   Mon Nov 28 14:09:09 2016 -0500

    Build.pl fails to find boost libraries

commit 3fa66c4970eb2235aa57041a5a318ddcb1910219
Author: Bill Waggoner <ctgreybeard@gmail.com>
Date:   Mon Nov 28 14:00:07 2016 -0500

    Build.pl fails to find boost correctly

Signed-off-by: Bill Waggoner <ctgreybeard@gmail.com>