### PR TITLE
Update WipeTowerPrusaMM.cpp

### DIFF
--- a/xs/src/libslic3r/GCode/WipeTowerPrusaMM.cpp
+++ b/xs/src/libslic3r/GCode/WipeTowerPrusaMM.cpp
@@ -10,6 +10,13 @@
 #include <strings.h>
 #endif /* __linux */
 
+/*-------ADD THIS ----------------*/
+/*----- Error --> strcasecmp was not declared ----*/
+#ifdef __GNUC__ 
+#include <strings.h>
+#endif
+/*-------ADD THIS ----------------*/
+
 #ifdef _MSC_VER 
 #define strcasecmp _stricmp
 #endif


### PR DESCRIPTION
Resolves compile error on Win XP / Win 7 32bit with native toolchain MinGW32-w64 on perl 5.26 or Citrusperl 5.24. No mysys or cygwin layers and no MS VS. - for open source reasons only open source toolchains and no temporaryly "free" tools from MS.