### PR TITLE
Many warnings fixed

### DIFF
--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -106,9 +106,9 @@ public:
     float height;
     
     ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), m_role(role) {};
-  ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), m_role(role) {};
+    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), m_role(role) {};
     ExtrusionPath(const ExtrusionPath &rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
-  ExtrusionPath(ExtrusionPath &&rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
+    ExtrusionPath(ExtrusionPath &&rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
 //    ExtrusionPath(ExtrusionRole role, const Flow &flow) : m_role(role), mm3_per_mm(flow.mm3_per_mm()), width(flow.width), height(flow.height) {};
 
     ExtrusionPath& operator=(const ExtrusionPath &rhs) { this->m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = rhs.polyline; return *this; }

--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -105,10 +105,10 @@ public:
     // Height of the extrusion, used for visualization purposed.
     float height;
     
-    ExtrusionPath(ExtrusionRole role) : m_role(role), mm3_per_mm(-1), width(-1), height(-1) {};
-    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : m_role(role), mm3_per_mm(mm3_per_mm), width(width), height(height) {};
-    ExtrusionPath(const ExtrusionPath &rhs) : m_role(rhs.m_role), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), polyline(rhs.polyline) {}
-    ExtrusionPath(ExtrusionPath &&rhs) : m_role(rhs.m_role), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), polyline(std::move(rhs.polyline)) {}
+    ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), m_role(role) {};
+  ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), m_role(role) {};
+    ExtrusionPath(const ExtrusionPath &rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
+  ExtrusionPath(ExtrusionPath &&rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
 //    ExtrusionPath(ExtrusionRole role, const Flow &flow) : m_role(role), mm3_per_mm(flow.mm3_per_mm()), width(flow.width), height(flow.height) {};
 
     ExtrusionPath& operator=(const ExtrusionPath &rhs) { this->m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = rhs.polyline; return *this; }

--- a/xs/src/libslic3r/Geometry.hpp
+++ b/xs/src/libslic3r/Geometry.hpp
@@ -134,7 +134,7 @@ class MedialAxis {
     double max_width;
     double min_width;
     MedialAxis(double _max_width, double _min_width, const ExPolygon* _expolygon = NULL)
-      : expolygon(_expolygon), max_width(_max_width), min_width(_min_width) {};
+        : expolygon(_expolygon), max_width(_max_width), min_width(_min_width) {};
     void build(ThickPolylines* polylines);
     void build(Polylines* polylines);
     

--- a/xs/src/libslic3r/Geometry.hpp
+++ b/xs/src/libslic3r/Geometry.hpp
@@ -48,8 +48,8 @@ static inline bool is_ccw(const Polygon &poly)
         return true;
 
     // 1) Find the lowest lexicographical point.
-    int     imin = 0;
-    for (int i = 1; i < poly.points.size(); ++ i) {
+    unsigned int imin = 0;
+    for (unsigned int i = 1; i < poly.points.size(); ++ i) {
         const Point &pmin = poly.points[imin];
         const Point &p    = poly.points[i];
         if (p.x < pmin.x || (p.x == pmin.x && p.y < pmin.y))
@@ -134,7 +134,7 @@ class MedialAxis {
     double max_width;
     double min_width;
     MedialAxis(double _max_width, double _min_width, const ExPolygon* _expolygon = NULL)
-        : max_width(_max_width), min_width(_min_width), expolygon(_expolygon) {};
+      : expolygon(_expolygon), max_width(_max_width), min_width(_min_width) {};
     void build(ThickPolylines* polylines);
     void build(Polylines* polylines);
     

--- a/xs/src/libslic3r/Line.hpp
+++ b/xs/src/libslic3r/Line.hpp
@@ -53,7 +53,7 @@ class ThickLine : public Line
     coordf_t a_width, b_width;
     
     ThickLine() : a_width(0), b_width(0) {};
-    ThickLine(Point _a, Point _b) : a_width(0), b_width(0), Line(_a, _b) {};
+  ThickLine(Point _a, Point _b) : Line(_a, _b), a_width(0), b_width(0) {};
 };
 
 class Linef

--- a/xs/src/libslic3r/Line.hpp
+++ b/xs/src/libslic3r/Line.hpp
@@ -53,7 +53,7 @@ class ThickLine : public Line
     coordf_t a_width, b_width;
     
     ThickLine() : a_width(0), b_width(0) {};
-  ThickLine(Point _a, Point _b) : Line(_a, _b), a_width(0), b_width(0) {};
+    ThickLine(Point _a, Point _b) : Line(_a, _b), a_width(0), b_width(0) {};
 };
 
 class Linef

--- a/xs/src/libslic3r/Model.hpp
+++ b/xs/src/libslic3r/Model.hpp
@@ -130,7 +130,7 @@ public:
     void print_info() const;
     
 private:        
-    ModelObject(Model *model) : m_model(model),  m_bounding_box_valid(false), layer_height_profile_valid(false) {}
+    ModelObject(Model *model) : layer_height_profile_valid(false), m_model(model), m_bounding_box_valid(false) {}
     ModelObject(Model *model, const ModelObject &other, bool copy_volumes = true);
     ModelObject& operator= (ModelObject other);
     void swap(ModelObject &other);

--- a/xs/src/libslic3r/Print.hpp
+++ b/xs/src/libslic3r/Print.hpp
@@ -144,7 +144,7 @@ public:
     BoundingBox bounding_box() const { return BoundingBox(Point(0,0), this->size); }
 
     // adds region_id, too, if necessary
-    void add_region_volume(int region_id, int volume_id) {
+    void add_region_volume(unsigned int region_id, int volume_id) {
         if (region_id >= region_volumes.size())
             region_volumes.resize(region_id + 1);
         region_volumes[region_id].push_back(volume_id);

--- a/xs/src/slic3r/GUI/3DScene.cpp
+++ b/xs/src/slic3r/GUI/3DScene.cpp
@@ -414,14 +414,12 @@ static void thick_lines_to_indexed_vertex_array(
     Line prev_line;
     // right, left, top, bottom
     int     idx_prev[4]      = { -1, -1, -1, -1 };
-    double  width_prev       = 0.;
     double  bottom_z_prev    = 0.;
     Pointf  b1_prev;
     Pointf  b2_prev;
     Vectorf v_prev;
     int     idx_initial[4]   = { -1, -1, -1, -1 };
     double  width_initial    = 0.;
-    double  bottom_z_initial = 0.;
 
     // loop once more in case of closed loops
     size_t lines_end = closed ? (lines.size() + 1) : lines.size();
@@ -459,9 +457,7 @@ static void thick_lines_to_indexed_vertex_array(
         int idx_b[4];
         int idx_last = int(volume.vertices_and_normals_interleaved.size() / 6);
 
-        bool width_different    = width_prev != width;
         bool bottom_z_different = bottom_z_prev != bottom_z;
-        width_prev    = width;
         bottom_z_prev = bottom_z;
 
         // Share top / bottom vertices if possible.
@@ -486,7 +482,6 @@ static void thick_lines_to_indexed_vertex_array(
         if (ii == 0) {
             // Start of the 1st line segment.
             width_initial    = width;
-            bottom_z_initial = bottom_z;
             memcpy(idx_initial, idx_a, sizeof(int) * 4);
         } else {
             // Continuing a previous segment.
@@ -579,7 +574,6 @@ static void thick_lines_to_indexed_vertex_array(
 
         prev_line = line;
         memcpy(idx_prev, idx_b, 4 * sizeof(int));
-        width_prev = width;
         bottom_z_prev = bottom_z;
         b1_prev = b1;
         b2_prev = b2;

--- a/xs/src/slic3r/GUI/3DScene.hpp
+++ b/xs/src/slic3r/GUI/3DScene.hpp
@@ -207,8 +207,8 @@ public:
         drag_group_id(-1),
         selected(false),
         hover(false),
-        qverts_range(0, size_t(-1)),
-        tverts_range(0, size_t(-1))
+        tverts_range(0, size_t(-1)),
+        qverts_range(0, size_t(-1))
     {
         color[0] = r;
         color[1] = g;


### PR DESCRIPTION
This cleans up a bunch of the warnings that gcc is reporting.  I'm seeing the warnings when compiling on RPi but I imagine that they are there for all platforms.