### PR TITLE
Missing prerequisites in Build.PL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -10,6 +10,8 @@ my %prereqs = qw(
     Devel::CheckLib                 0
     ExtUtils::MakeMaker             6.80
     ExtUtils::ParseXS               3.22
+    ExtUtils::XSpp                  0
+    ExtUtils::Typemaps              0
     File::Basename                  0
     File::Spec                      0
     Getopt::Long                    0


### PR DESCRIPTION
I was unable to compile without ExtUtils::XSpp and ExtUtils::Typemaps .

My platform is a fresh install of OctoPi on Raspberry Pi.

I'm not sure what the `0` in those lines does.