### PR TITLE
Fix environment variable setting on Windows

### DIFF
--- a/xs/src/libslic3r/Config.cpp
+++ b/xs/src/libslic3r/Config.cpp
@@ -18,10 +18,6 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <string.h>
 
-#if defined(_WIN32) && !defined(setenv) && defined(_putenv_s)
-#define setenv(k, v, o) _putenv_s(k, v)
-#endif
-
 namespace Slic3r {
 
 std::string escape_string_cstyle(const std::string &str)
@@ -309,7 +305,6 @@ double ConfigBase::get_abs_value(const t_config_option_key &opt_key, double rati
 
 void ConfigBase::setenv_()
 {
-#ifdef setenv
     t_config_option_keys opt_keys = this->keys();
     for (t_config_option_keys::const_iterator it = opt_keys.begin(); it != opt_keys.end(); ++it) {
         // prepend the SLIC3R_ prefix
@@ -322,9 +317,8 @@ void ConfigBase::setenv_()
         for (size_t i = 0; i < envname.size(); ++i)
             envname[i] = (envname[i] <= 'z' && envname[i] >= 'a') ? envname[i]-('a'-'A') : envname[i];
         
-        setenv(envname.c_str(), this->serialize(*it).c_str(), 1);
+        boost::nowide::setenv(envname.c_str(), this->serialize(*it).c_str(), 1);
     }
-#endif
 }
 
 void ConfigBase::load(const std::string &file)


### PR DESCRIPTION
I noticed that environment variables were not passed to post processing scripts on Windows, so this fixes that.

The previous way of checking that `_putenv_s` is defined does not work, because `_putenv_s `is a function and not a define. This is a partial application of alexrj/Slic3r@31115e0369747b1e1c45cbe3f2a90f6dff66666a

I tried cherry picking the whole commit, but unicode is already handled diffrently here, so that would have been a lot of work.