### PR TITLE
Fixed instant crash with blank/0 layer height

### DIFF
--- a/xs/src/slic3r/GUI/PresetHints.cpp
+++ b/xs/src/slic3r/GUI/PresetHints.cpp
@@ -238,6 +238,10 @@ std::string PresetHints::recommended_thin_wall_thickness(const PresetBundle &pre
     bool    thin_walls                          = print_config.opt_bool("thin_walls");
     float   nozzle_diameter                     = float(printer_config.opt_float("nozzle_diameter", 0));
     
+    if (layer_height <= 0) { //don't display recommendations and avoid crash
+        return "";
+    }
+
     Flow    external_perimeter_flow             = Flow::new_from_config_width(
         frExternalPerimeter, 
         *print_config.opt<ConfigOptionFloatOrPercent>("external_perimeter_extrusion_width"), 


### PR DESCRIPTION
Currently, when updating the suggestion text on the Print Settings/Layers tab, a blank/0 value for height causes `Flow::new_from_config_width` to crash. This modification simply disables the suggestion text when the layer height is invalid, while still leaving in the normal sanity checks for actual slicing.

Fixes #691.