### PR TITLE
Neosanding infill & gyroid infill & 1 top perimeter option

### DIFF
--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -492,18 +492,18 @@ sub Render {
 
 sub _draw {
     my ($self, $object, $print_z, $path) = @_;
-	
-	if($path->isa('Slic3r::ExtrusionPath::Collection')){
-		$self->_draw($object, $print_z, $_) for @{$path};
-	}else{
     
-		my @paths = ($path->isa('Slic3r::ExtrusionLoop') || $path->isa('Slic3r::ExtrusionMultiPath'))
-			? @$path
-			: ($path);
-		
-		$self->_draw_path($object, $print_z, $_) for @paths;
-		
-	}
+    if($path->isa('Slic3r::ExtrusionPath::Collection')){
+        $self->_draw($object, $print_z, $_) for @{$path};
+    }else{
+    
+        my @paths = ($path->isa('Slic3r::ExtrusionLoop') || $path->isa('Slic3r::ExtrusionMultiPath'))
+            ? @$path
+            : ($path);
+        
+        $self->_draw_path($object, $print_z, $_) for @paths;
+        
+    }
 }
 
 sub _draw_path {
@@ -537,8 +537,8 @@ sub _draw_path {
             glVertex2f(@{$line->a});
             glVertex2f(@{$line->b});
             glEnd();
-		}
-	}
+        }
+    }
 }
 
 sub _simulate_extrusion {

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -492,12 +492,18 @@ sub Render {
 
 sub _draw {
     my ($self, $object, $print_z, $path) = @_;
+	
+	if($path->isa('Slic3r::ExtrusionPath::Collection')){
+		$self->_draw($object, $print_z, $_) for @{$path};
+	}else{
     
-    my @paths = ($path->isa('Slic3r::ExtrusionLoop') || $path->isa('Slic3r::ExtrusionMultiPath'))
-        ? @$path
-        : ($path);
-    
-    $self->_draw_path($object, $print_z, $_) for @paths;
+		my @paths = ($path->isa('Slic3r::ExtrusionLoop') || $path->isa('Slic3r::ExtrusionMultiPath'))
+			? @$path
+			: ($path);
+		
+		$self->_draw_path($object, $print_z, $_) for @paths;
+		
+	}
 }
 
 sub _draw_path {

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -1001,7 +1001,7 @@ sub _update {
     my $have_perimeters = $config->perimeters > 0;
     $self->get_field($_)->toggle($have_perimeters)
         for qw(extra_perimeters ensure_vertical_shell_thickness thin_walls overhangs seam_position external_perimeters_first
-            external_perimeter_extrusion_width
+            external_perimeter_extrusion_width only_one_perimeter_top
             perimeter_speed small_perimeter_speed external_perimeter_speed);
     
     my $have_infill = $config->fill_density > 0;

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -608,6 +608,7 @@ sub build {
         {
             my $optgroup = $page->new_optgroup('Quality (slower slicing)');
             $optgroup->append_single_option_line('extra_perimeters');
+            $optgroup->append_single_option_line('only_one_perimeter_top');
             $optgroup->append_single_option_line('ensure_vertical_shell_thickness');
             $optgroup->append_single_option_line('avoid_crossing_perimeters');
             $optgroup->append_single_option_line('thin_walls');

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -626,7 +626,8 @@ sub build {
             my $optgroup = $page->new_optgroup('Infill');
             $optgroup->append_single_option_line('fill_density');
             $optgroup->append_single_option_line('fill_pattern');
-            $optgroup->append_single_option_line('external_fill_pattern');
+            $optgroup->append_single_option_line('top_fill_pattern');
+            $optgroup->append_single_option_line('bottom_fill_pattern');
         }
         {
             my $optgroup = $page->new_optgroup('Reducing printing time');
@@ -979,7 +980,8 @@ sub _update {
     }
     
     if ($config->fill_density == 100
-        && !first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{external_fill_pattern}{values}}) {
+        && (!first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{top_fill_pattern}{values}}
+			|| !first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{bottom_fill_pattern}{values}})) {
         my $dialog = Wx::MessageDialog->new($self,
             "The " . $config->fill_pattern . " infill pattern is not supposed to work at 100% density.\n"
             . "\nShall I switch to rectilinear fill pattern?",
@@ -1010,7 +1012,7 @@ sub _update {
     my $have_solid_infill = ($config->top_solid_layers > 0) || ($config->bottom_solid_layers > 0);
     # solid_infill_extruder uses the same logic as in Print::extruders()
     $self->get_field($_)->toggle($have_solid_infill)
-        for qw(external_fill_pattern infill_first solid_infill_extruder solid_infill_extrusion_width
+        for qw(infill_first solid_infill_extruder solid_infill_extrusion_width
             solid_infill_speed);
     
     $self->get_field($_)->toggle($have_infill || $have_solid_infill)
@@ -1020,7 +1022,11 @@ sub _update {
     
     my $have_top_solid_infill = $config->top_solid_layers > 0;
     $self->get_field($_)->toggle($have_top_solid_infill)
-        for qw(top_infill_extrusion_width top_solid_infill_speed);
+        for qw(top_fill_pattern top_infill_extrusion_width top_solid_infill_speed);
+    
+    my $have_bottom_solid_infill = $config->bottom_solid_layers > 0;
+    $self->get_field($_)->toggle($have_bottom_solid_infill)
+        for qw(bottom_fill_pattern);
     
     my $have_default_acceleration = $config->default_acceleration > 0;
     $self->get_field($_)->toggle($have_default_acceleration)

--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -982,7 +982,7 @@ sub _update {
     
     if ($config->fill_density == 100
         && (!first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{top_fill_pattern}{values}}
-			|| !first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{bottom_fill_pattern}{values}})) {
+            || !first { $_ eq $config->fill_pattern } @{$Slic3r::Config::Options->{bottom_fill_pattern}{values}})) {
         my $dialog = Wx::MessageDialog->new($self,
             "The " . $config->fill_pattern . " infill pattern is not supposed to work at 100% density.\n"
             . "\nShall I switch to rectilinear fill pattern?",

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -369,7 +369,8 @@ Usage: slic3r.pl [ OPTIONS ] [ file.stl ] [ file2.stl ] ...
     --fill-density      Infill density (range: 0%-100%, default: $config->{fill_density}%)
     --fill-angle        Infill angle in degrees (range: 0-90, default: $config->{fill_angle})
     --fill-pattern      Pattern to use to fill non-solid layers (default: $config->{fill_pattern})
-    --external-fill-pattern Pattern to use to fill solid layers (default: $config->{external_fill_pattern})
+    --top-fill-pattern Pattern to use to fill solid layers (default: $config->{top_fill_pattern})
+    --bottom-fill-pattern Pattern to use to fill solid layers (default: $config->{bottom_fill_pattern})
     --start-gcode       Load initial G-code from the supplied file. This will overwrite
                         the default command (home all axes [G28]).
     --end-gcode         Load final G-code from the supplied file. This will overwrite 

--- a/t/fill.t
+++ b/t/fill.t
@@ -165,7 +165,8 @@ SKIP:
 for my $pattern (qw(rectilinear honeycomb hilbertcurve concentric)) {
     my $config = Slic3r::Config::new_from_defaults;
     $config->set('fill_pattern', $pattern);
-    $config->set('external_fill_pattern', $pattern);
+    $config->set('top_fill_pattern', $pattern);
+    $config->set('bottom_fill_pattern', $pattern);
     $config->set('perimeters', 1);
     $config->set('skirts', 0);
     $config->set('fill_density', 20);

--- a/utils/zsh/functions/_slic3r
+++ b/utils/zsh/functions/_slic3r
@@ -57,8 +57,8 @@ _arguments -S \
     '--solid-layers[specify number of solid layers to do for top/bottom surfaces]:number of layers for top/bottom surfaces' \
     '--fill-density[specify infill density]:infill density in percent' \
     '--fill-angle[specify infill angle]:infill angle in degrees' \
-    '--fill-pattern[specify pattern used for infill]:infill pattern:(rectilinear line concentric honeycomb hilbertcurve archimedeanchords octagramspiral)' \
-    '--solid-fill-pattern[specify pattern used for solid layers]:solid fill pattern:(rectilinear concentric hilbertcurve archimedeanchords octagramspiral)' \
+    '--fill-pattern[specify pattern used for infill]:infill pattern:(rectilinear line concentric honeycomb hilbertcurve archimedeanchords octagramspiral smooth)' \
+    '--solid-fill-pattern[specify pattern used for solid layers]:solid fill pattern:(rectilinear concentric hilbertcurve archimedeanchords octagramspiral smooth)' \
     '--start-gcode[load initial G-code from file]:start G-code file:_files -g "*.(#i)(gcode)(-.)"' \
     '--end-gcode[load final G-code from file]:end G-code file:_files -g "*.(#i)(gcode)(-.)"' \
     '--layer-gcode[load layer-change G-code from file]:layer-change G-code file:_files -g "*.(#i)(gcode)(-.)"' \

--- a/xs/CMakeLists.txt
+++ b/xs/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(libslic3r STATIC
     ${LIBDIR}/libslic3r/Fill/Fill.hpp
     ${LIBDIR}/libslic3r/Fill/Fill3DHoneycomb.cpp
     ${LIBDIR}/libslic3r/Fill/Fill3DHoneycomb.hpp
+    ${LIBDIR}/libslic3r/Fill/FillGyroid.cpp
+    ${LIBDIR}/libslic3r/Fill/FillGyroid.hpp
     ${LIBDIR}/libslic3r/Fill/FillBase.cpp
     ${LIBDIR}/libslic3r/Fill/FillBase.hpp
     ${LIBDIR}/libslic3r/Fill/FillConcentric.cpp

--- a/xs/CMakeLists.txt
+++ b/xs/CMakeLists.txt
@@ -66,6 +66,8 @@ add_library(libslic3r STATIC
     ${LIBDIR}/libslic3r/Fill/FillConcentric.hpp
     ${LIBDIR}/libslic3r/Fill/FillHoneycomb.cpp
     ${LIBDIR}/libslic3r/Fill/FillHoneycomb.hpp
+    ${LIBDIR}/libslic3r/Fill/FillGyroid.cpp
+    ${LIBDIR}/libslic3r/Fill/FillGyroid.hpp
     ${LIBDIR}/libslic3r/Fill/FillPlanePath.cpp
     ${LIBDIR}/libslic3r/Fill/FillPlanePath.hpp
     ${LIBDIR}/libslic3r/Fill/FillRectilinear.cpp

--- a/xs/src/libslic3r/ExtrusionEntityCollection.cpp
+++ b/xs/src/libslic3r/ExtrusionEntityCollection.cpp
@@ -6,7 +6,7 @@
 namespace Slic3r {
 
 ExtrusionEntityCollection::ExtrusionEntityCollection(const ExtrusionPaths &paths)
-    : no_sort(false), name("blank")
+    : no_sort(false)
 {
     this->append(paths);
 }
@@ -18,7 +18,6 @@ ExtrusionEntityCollection& ExtrusionEntityCollection::operator= (const Extrusion
         this->entities[i] = this->entities[i]->clone();
     this->orig_indices  = other.orig_indices;
     this->no_sort       = other.no_sort;
-    this->name       = "="+other.name;
     return *this;
 }
 
@@ -28,7 +27,6 @@ ExtrusionEntityCollection::swap(ExtrusionEntityCollection &c)
     std::swap(this->entities, c.entities);
     std::swap(this->orig_indices, c.orig_indices);
     std::swap(this->no_sort, c.no_sort);
-    std::swap(this->name, c.name);
 }
 
 void ExtrusionEntityCollection::clear()
@@ -36,7 +34,6 @@ void ExtrusionEntityCollection::clear()
 	for (size_t i = 0; i < this->entities.size(); ++i)
 		delete this->entities[i];
     this->entities.clear();
-    this->name       = "clear";
 }
 
 ExtrusionEntityCollection::operator ExtrusionPaths() const
@@ -56,14 +53,12 @@ ExtrusionEntityCollection::clone() const
     for (size_t i = 0; i < coll->entities.size(); ++i)
         coll->entities[i] = this->entities[i]->clone();
 	
-	coll->name = "clone_" + name;
     return coll;
 }
 
 void
 ExtrusionEntityCollection::reverse()
 {
-	std::cout<<"REVERSE "<<can_reverse()<<" : "<<name<<"\n";
     for (ExtrusionEntitiesPtr::iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
         // Don't reverse it if it's a loop, as it doesn't change anything in terms of elements ordering
         // and caller might rely on winding order
@@ -110,13 +105,10 @@ ExtrusionEntityCollection ExtrusionEntityCollection::chained_path_from(Point sta
 
 void ExtrusionEntityCollection::chained_path_from(Point start_near, ExtrusionEntityCollection* retval, bool no_reverse, ExtrusionRole role, std::vector<size_t>* orig_indices) const
 {
-	std::cout<<"chained_path_from "<<name;
     if (this->no_sort) {
-		std::cout<<" no sort! return this\n";
         *retval = *this;
         return;
     }
-		std::cout<<" sort this\n";
     retval->entities.reserve(this->entities.size());
     retval->orig_indices.reserve(this->entities.size());
     
@@ -198,7 +190,6 @@ ExtrusionEntityCollection::items_count() const
 void
 ExtrusionEntityCollection::flatten(ExtrusionEntityCollection* retval) const
 {
-	std::cout<<"Flatten"<<name<<"\n";
     for (ExtrusionEntitiesPtr::const_iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
         if ((*it)->is_collection()) {
             ExtrusionEntityCollection* collection = dynamic_cast<ExtrusionEntityCollection*>(*it);
@@ -221,7 +212,6 @@ ExtrusionEntityCollection::flatten() const
 void
 ExtrusionEntityCollection::flattenIfSortable(ExtrusionEntityCollection* retval) const
 {
-	std::cout<<"flattenIfSortable"<<name<<"\n";
 	if(no_sort){
 		ExtrusionEntityCollection *unsortable = new ExtrusionEntityCollection(*this);
 		retval->append(*unsortable);

--- a/xs/src/libslic3r/ExtrusionEntityCollection.cpp
+++ b/xs/src/libslic3r/ExtrusionEntityCollection.cpp
@@ -31,8 +31,8 @@ ExtrusionEntityCollection::swap(ExtrusionEntityCollection &c)
 
 void ExtrusionEntityCollection::clear()
 {
-	for (size_t i = 0; i < this->entities.size(); ++i)
-		delete this->entities[i];
+    for (size_t i = 0; i < this->entities.size(); ++i)
+        delete this->entities[i];
     this->entities.clear();
 }
 
@@ -52,7 +52,7 @@ ExtrusionEntityCollection::clone() const
     ExtrusionEntityCollection* coll = new ExtrusionEntityCollection(*this);
     for (size_t i = 0; i < coll->entities.size(); ++i)
         coll->entities[i] = this->entities[i]->clone();
-	
+    
     return coll;
 }
 
@@ -212,28 +212,28 @@ ExtrusionEntityCollection::flatten() const
 void
 ExtrusionEntityCollection::flattenIfSortable(ExtrusionEntityCollection* retval) const
 {
-	if(no_sort){
-		ExtrusionEntityCollection *unsortable = new ExtrusionEntityCollection(*this);
-		retval->append(*unsortable);
-		unsortable->entities.clear();
-		for (ExtrusionEntitiesPtr::const_iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
-			if ((*it)->is_collection()) {
-				ExtrusionEntityCollection* collection = dynamic_cast<ExtrusionEntityCollection*>(*it);
-				collection->flattenIfSortable(unsortable);
-			} else {
-				unsortable->append(**it);
-			}
-		}
-	}else{
-		for (ExtrusionEntitiesPtr::const_iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
-			if ((*it)->is_collection()) {
-				ExtrusionEntityCollection* collection = dynamic_cast<ExtrusionEntityCollection*>(*it);
-				retval->append(collection->flattenIfSortable().entities);
-			} else {
-				retval->append(**it);
-			}
-		}
-	}
+    if(no_sort){
+        ExtrusionEntityCollection *unsortable = new ExtrusionEntityCollection(*this);
+        retval->append(*unsortable);
+        unsortable->entities.clear();
+        for (ExtrusionEntitiesPtr::const_iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
+            if ((*it)->is_collection()) {
+                ExtrusionEntityCollection* collection = dynamic_cast<ExtrusionEntityCollection*>(*it);
+                collection->flattenIfSortable(unsortable);
+            } else {
+                unsortable->append(**it);
+            }
+        }
+    }else{
+        for (ExtrusionEntitiesPtr::const_iterator it = this->entities.begin(); it != this->entities.end(); ++it) {
+            if ((*it)->is_collection()) {
+                ExtrusionEntityCollection* collection = dynamic_cast<ExtrusionEntityCollection*>(*it);
+                retval->append(collection->flattenIfSortable().entities);
+            } else {
+                retval->append(**it);
+            }
+        }
+    }
 }
 
 ExtrusionEntityCollection

--- a/xs/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/xs/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -13,13 +13,14 @@ public:
     ExtrusionEntitiesPtr entities;     // we own these entities
     std::vector<size_t> orig_indices;  // handy for XS
     bool no_sort;
-    ExtrusionEntityCollection(): no_sort(false) {};
-    ExtrusionEntityCollection(const ExtrusionEntityCollection &other) : orig_indices(other.orig_indices), no_sort(other.no_sort) { this->append(other.entities); }
-    ExtrusionEntityCollection(ExtrusionEntityCollection &&other) : entities(std::move(other.entities)), orig_indices(std::move(other.orig_indices)), no_sort(other.no_sort) {}
+    std::string name;
+    ExtrusionEntityCollection(): no_sort(false), name("nothing") {};
+    ExtrusionEntityCollection(const ExtrusionEntityCollection &other) : orig_indices(other.orig_indices), no_sort(other.no_sort), name(other.name) { this->append(other.entities); }
+    ExtrusionEntityCollection(ExtrusionEntityCollection &&other) : entities(std::move(other.entities)), orig_indices(std::move(other.orig_indices)), no_sort(other.no_sort), name(other.name) {}
     explicit ExtrusionEntityCollection(const ExtrusionPaths &paths);
     ExtrusionEntityCollection& operator=(const ExtrusionEntityCollection &other);
     ExtrusionEntityCollection& operator=(ExtrusionEntityCollection &&other) 
-        { this->entities = std::move(other.entities); this->orig_indices = std::move(other.orig_indices); this->no_sort = other.no_sort; return *this; }
+        { this->entities = std::move(other.entities); this->orig_indices = std::move(other.orig_indices); this->no_sort = other.no_sort; this->name = other.name; return *this; }
     ~ExtrusionEntityCollection() { clear(); }
     explicit operator ExtrusionPaths() const;
     
@@ -78,6 +79,8 @@ public:
     size_t items_count() const;
     void flatten(ExtrusionEntityCollection* retval) const;
     ExtrusionEntityCollection flatten() const;
+    void flattenIfSortable(ExtrusionEntityCollection* retval) const;
+    ExtrusionEntityCollection flattenIfSortable() const;
     double min_mm3_per_mm() const;
 
     // Following methods shall never be called on an ExtrusionEntityCollection.

--- a/xs/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/xs/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -13,14 +13,13 @@ public:
     ExtrusionEntitiesPtr entities;     // we own these entities
     std::vector<size_t> orig_indices;  // handy for XS
     bool no_sort;
-    std::string name;
-    ExtrusionEntityCollection(): no_sort(false), name("nothing") {};
-    ExtrusionEntityCollection(const ExtrusionEntityCollection &other) : orig_indices(other.orig_indices), no_sort(other.no_sort), name(other.name) { this->append(other.entities); }
-    ExtrusionEntityCollection(ExtrusionEntityCollection &&other) : entities(std::move(other.entities)), orig_indices(std::move(other.orig_indices)), no_sort(other.no_sort), name(other.name) {}
+    ExtrusionEntityCollection(): no_sort(false) {};
+    ExtrusionEntityCollection(const ExtrusionEntityCollection &other) : orig_indices(other.orig_indices), no_sort(other.no_sort) { this->append(other.entities); }
+    ExtrusionEntityCollection(ExtrusionEntityCollection &&other) : entities(std::move(other.entities)), orig_indices(std::move(other.orig_indices)), no_sort(other.no_sort) {}
     explicit ExtrusionEntityCollection(const ExtrusionPaths &paths);
     ExtrusionEntityCollection& operator=(const ExtrusionEntityCollection &other);
     ExtrusionEntityCollection& operator=(ExtrusionEntityCollection &&other) 
-        { this->entities = std::move(other.entities); this->orig_indices = std::move(other.orig_indices); this->no_sort = other.no_sort; this->name = other.name; return *this; }
+        { this->entities = std::move(other.entities); this->orig_indices = std::move(other.orig_indices); this->no_sort = other.no_sort; return *this; }
     ~ExtrusionEntityCollection() { clear(); }
     explicit operator ExtrusionPaths() const;
     

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -237,9 +237,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
 			// so we can safely ignore the slight variation that might have
 			// been applied to $f->flow_spacing
 		} else {
-			std::cout<<"before : flow"<<(flow.mm3_per_mm())<<", width"<<(flow.width)<<", height"<<(flow.height)<<"\n";
 			flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
-			std::cout<<"after : flow"<<(flow.mm3_per_mm())<<", width"<<(flow.width)<<", height"<<(flow.height)<<"\n";
 		}
 		
 		//check if the infill want to be able to create the whole extrusion or we can do the standard work.
@@ -255,6 +253,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
 			// Save into layer.
 			auto *eec = new ExtrusionEntityCollection();
 			out.entities.push_back(eec);
+			eec->name = "normal fill";
 			// Only concentric fills are not sorted.
 			eec->no_sort = f->no_sort();
 			extrusion_entities_append_paths(
@@ -275,6 +274,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
     // Why the paths are unpacked?
     for (const ExtrusionEntity *thin_fill : layerm.thin_fills.entities) {
         ExtrusionEntityCollection &collection = *(new ExtrusionEntityCollection());
+		collection.name="thin_wall";
         out.entities.push_back(&collection);
         collection.entities.push_back(thin_fill->clone());
     }

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -215,7 +215,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
         }
 
         f->layer_id = layerm.layer()->id();
-		f->layer_height = layerm.layer()->object()->config.layer_height.value;
+        f->layer_height = layerm.layer()->object()->config.layer_height.value;
         f->z = layerm.layer()->print_z;
         f->angle = float(Geometry::deg2rad(layerm.region()->config.fill_angle.value));
         // Maximum length of the perimeter segment linking two infill lines.
@@ -229,42 +229,42 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
         params.density = 0.01 * density;
 //        params.dont_adjust = true;
         params.dont_adjust = false;
-		
-		
-		// calculate actual flow from spacing (which might have been adjusted by the infill
-		// pattern generator)
-		if (using_internal_flow) {
-			// if we used the internal flow we're not doing a solid infill
-			// so we can safely ignore the slight variation that might have
-			// been applied to $f->flow_spacing
-		} else {
-			flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
-		}
-		
-		//check if the infill want to be able to create the whole extrusion or we can do the standard work.
-		if(f->can_create_extrusion_entity_collection()){
-			flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
-			f->fill_surface_extrusion(&surface, params, flow, out);
-		}else{
-			Polylines polylines = f->fill_surface(&surface, params);
-			if (polylines.empty())
-				continue;
+        
+        
+        // calculate actual flow from spacing (which might have been adjusted by the infill
+        // pattern generator)
+        if (using_internal_flow) {
+            // if we used the internal flow we're not doing a solid infill
+            // so we can safely ignore the slight variation that might have
+            // been applied to $f->flow_spacing
+        } else {
+            flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
+        }
+        
+        //check if the infill want to be able to create the whole extrusion or we can do the standard work.
+        if(f->can_create_extrusion_entity_collection()){
+            flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
+            f->fill_surface_extrusion(&surface, params, flow, out);
+        }else{
+            Polylines polylines = f->fill_surface(&surface, params);
+            if (polylines.empty())
+                continue;
 
 
-			// Save into layer.
-			auto *eec = new ExtrusionEntityCollection();
-			out.entities.push_back(eec);
-			// Only concentric fills are not sorted.
-			eec->no_sort = f->no_sort();
-			extrusion_entities_append_paths(
-				eec->entities, STDMOVE(polylines),
-				is_bridge ?
-					erBridgeInfill :
-					(surface.is_solid() ?
-						((surface.surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
-						erInternalInfill),
-				flow.mm3_per_mm(), flow.width, flow.height);
-		}
+            // Save into layer.
+            auto *eec = new ExtrusionEntityCollection();
+            out.entities.push_back(eec);
+            // Only concentric fills are not sorted.
+            eec->no_sort = f->no_sort();
+            extrusion_entities_append_paths(
+                eec->entities, STDMOVE(polylines),
+                is_bridge ?
+                    erBridgeInfill :
+                    (surface.is_solid() ?
+                        ((surface.surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
+                        erInternalInfill),
+                flow.mm3_per_mm(), flow.width, flow.height);
+        }
     }
 
     // add thin fill regions

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -215,6 +215,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
         }
 
         f->layer_id = layerm.layer()->id();
+		f->layer_height = layerm.layer()->object()->config.layer_height.value;
         f->z = layerm.layer()->print_z;
         f->angle = float(Geometry::deg2rad(layerm.region()->config.fill_angle.value));
         // Maximum length of the perimeter segment linking two infill lines.

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -228,33 +228,40 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
         params.density = 0.01 * density;
 //        params.dont_adjust = true;
         params.dont_adjust = false;
-        Polylines polylines = f->fill_surface(&surface, params);
-        if (polylines.empty())
-            continue;
+		
+		//check if the infill want to be able to create the whole extrusion or we can do the standard work.
+		if(f->can_create_extrusion_entity_collection()){
+			flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
+			f->fill_surface_extrusion(&surface, params, flow, out);
+		}else{
+			Polylines polylines = f->fill_surface(&surface, params);
+			if (polylines.empty())
+				continue;
 
-        // calculate actual flow from spacing (which might have been adjusted by the infill
-        // pattern generator)
-        if (using_internal_flow) {
-            // if we used the internal flow we're not doing a solid infill
-            // so we can safely ignore the slight variation that might have
-            // been applied to $f->flow_spacing
-        } else {
-            flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
-        }
+			// calculate actual flow from spacing (which might have been adjusted by the infill
+			// pattern generator)
+			if (using_internal_flow) {
+				// if we used the internal flow we're not doing a solid infill
+				// so we can safely ignore the slight variation that might have
+				// been applied to $f->flow_spacing
+			} else {
+				flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
+			}
 
-        // Save into layer.
-        auto *eec = new ExtrusionEntityCollection();
-        out.entities.push_back(eec);
-        // Only concentric fills are not sorted.
-        eec->no_sort = f->no_sort();
-        extrusion_entities_append_paths(
-            eec->entities, STDMOVE(polylines),
-            is_bridge ?
-                erBridgeInfill :
-                (surface.is_solid() ?
-                    ((surface.surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
-                    erInternalInfill),
-            flow.mm3_per_mm(), flow.width, flow.height);
+			// Save into layer.
+			auto *eec = new ExtrusionEntityCollection();
+			out.entities.push_back(eec);
+			// Only concentric fills are not sorted.
+			eec->no_sort = f->no_sort();
+			extrusion_entities_append_paths(
+				eec->entities, STDMOVE(polylines),
+				is_bridge ?
+					erBridgeInfill :
+					(surface.is_solid() ?
+						((surface.surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
+						erInternalInfill),
+				flow.mm3_per_mm(), flow.width, flow.height);
+		}
     }
 
     // add thin fill regions

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -229,6 +229,19 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
 //        params.dont_adjust = true;
         params.dont_adjust = false;
 		
+		
+		// calculate actual flow from spacing (which might have been adjusted by the infill
+		// pattern generator)
+		if (using_internal_flow) {
+			// if we used the internal flow we're not doing a solid infill
+			// so we can safely ignore the slight variation that might have
+			// been applied to $f->flow_spacing
+		} else {
+			std::cout<<"before : flow"<<(flow.mm3_per_mm())<<", width"<<(flow.width)<<", height"<<(flow.height)<<"\n";
+			flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
+			std::cout<<"after : flow"<<(flow.mm3_per_mm())<<", width"<<(flow.width)<<", height"<<(flow.height)<<"\n";
+		}
+		
 		//check if the infill want to be able to create the whole extrusion or we can do the standard work.
 		if(f->can_create_extrusion_entity_collection()){
 			flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
@@ -238,15 +251,6 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
 			if (polylines.empty())
 				continue;
 
-			// calculate actual flow from spacing (which might have been adjusted by the infill
-			// pattern generator)
-			if (using_internal_flow) {
-				// if we used the internal flow we're not doing a solid infill
-				// so we can safely ignore the slight variation that might have
-				// been applied to $f->flow_spacing
-			} else {
-				flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
-			}
 
 			// Save into layer.
 			auto *eec = new ExtrusionEntityCollection();

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -241,30 +241,9 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
             flow = Flow::new_from_spacing(f->spacing, flow.nozzle_diameter, h, is_bridge || f->use_bridge_flow());
         }
         
-        //check if the infill want to be able to create the whole extrusion or we can do the standard work.
-        if(f->can_create_extrusion_entity_collection()){
-            flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
-            f->fill_surface_extrusion(&surface, params, flow, out);
-        }else{
-            Polylines polylines = f->fill_surface(&surface, params);
-            if (polylines.empty())
-                continue;
+        flow.bridge = is_bridge; //i'm not 100% sure of that line [merill]
+        f->fill_surface_extrusion(&surface, params, flow, out);
 
-
-            // Save into layer.
-            auto *eec = new ExtrusionEntityCollection();
-            out.entities.push_back(eec);
-            // Only concentric fills are not sorted.
-            eec->no_sort = f->no_sort();
-            extrusion_entities_append_paths(
-                eec->entities, STDMOVE(polylines),
-                is_bridge ?
-                    erBridgeInfill :
-                    (surface.is_solid() ?
-                        ((surface.surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
-                        erInternalInfill),
-                flow.mm3_per_mm(), flow.width, flow.height);
-        }
     }
 
     // add thin fill regions

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -69,7 +69,8 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
                 if (surface.is_solid() && (!surface.is_bridge() || layerm.layer()->id() == 0)) {
                     group_attrib[i].is_solid = true;
                     group_attrib[i].flow_width = (surface.surface_type == stTop) ? top_solid_infill_flow.width : solid_infill_flow.width;
-                    group_attrib[i].pattern = surface.is_external() ? layerm.region()->config.external_fill_pattern.value : ipRectilinear;
+                    group_attrib[i].pattern = (surface.surface_type == stTop && surface.is_external()) ? layerm.region()->config.top_fill_pattern.value : ipRectilinear;
+                    group_attrib[i].pattern = (surface.surface_type == stBottom && surface.is_external()) ? layerm.region()->config.bottom_fill_pattern.value : ipRectilinear;
                 }
             }
             // Loop through solid groups, find compatible groups and append them to this one.
@@ -161,7 +162,7 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
         if (surface.is_solid()) {
             density = 100.;
             fill_pattern = (surface.is_external() && ! is_bridge) ? 
-                layerm.region()->config.external_fill_pattern.value :
+                (surface.surface_type == stTop ? layerm.region()->config.top_fill_pattern.value : layerm.region()->config.bottom_fill_pattern.value) :
                 ipRectilinear;
         } else if (density <= 0)
             continue;

--- a/xs/src/libslic3r/Fill/Fill.cpp
+++ b/xs/src/libslic3r/Fill/Fill.cpp
@@ -253,7 +253,6 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
 			// Save into layer.
 			auto *eec = new ExtrusionEntityCollection();
 			out.entities.push_back(eec);
-			eec->name = "normal fill";
 			// Only concentric fills are not sorted.
 			eec->no_sort = f->no_sort();
 			extrusion_entities_append_paths(
@@ -274,7 +273,6 @@ void make_fill(LayerRegion &layerm, ExtrusionEntityCollection &out)
     // Why the paths are unpacked?
     for (const ExtrusionEntity *thin_fill : layerm.thin_fills.entities) {
         ExtrusionEntityCollection &collection = *(new ExtrusionEntityCollection());
-		collection.name="thin_wall";
         out.entities.push_back(&collection);
         collection.entities.push_back(thin_fill->clone());
     }

--- a/xs/src/libslic3r/Fill/FillBase.cpp
+++ b/xs/src/libslic3r/Fill/FillBase.cpp
@@ -22,9 +22,7 @@ Fill* Fill::new_from_type(const InfillPattern type)
     case ipConcentric:          return new FillConcentric();
     case ipHoneycomb:           return new FillHoneycomb();
     case ip3DHoneycomb:         return new Fill3DHoneycomb();
-    case ipGyroid:              return new FillGyroid();
-    case ipGyroidThin:          return new FillGyroidThin();
-    case ipGyroidThick:         return new FillGyroidThick();
+    case ipGyroid:              return new FillGyroidThin();
     case ipRectilinear:         return new FillRectilinear2();
 //  case ipRectilinear:         return new FillRectilinear();
     case ipSmooth:              return new FillSmooth();

--- a/xs/src/libslic3r/Fill/FillBase.cpp
+++ b/xs/src/libslic3r/Fill/FillBase.cpp
@@ -23,6 +23,7 @@ Fill* Fill::new_from_type(const InfillPattern type)
     case ip3DHoneycomb:         return new Fill3DHoneycomb();
     case ipRectilinear:         return new FillRectilinear2();
 //  case ipRectilinear:         return new FillRectilinear();
+    case ipSmooth:              return new FillSmooth();
     case ipLine:                return new FillLine();
     case ipGrid:                return new FillGrid2();
     case ipTriangles:           return new FillTriangles();

--- a/xs/src/libslic3r/Fill/FillBase.cpp
+++ b/xs/src/libslic3r/Fill/FillBase.cpp
@@ -94,8 +94,8 @@ std::pair<float, Point> Fill::_infill_direction(const Surface *surface) const
     // set infill angle
     float out_angle = this->angle;
 
-	if (out_angle == FLT_MAX) {
-		//FIXME Vojtech: Add a warning?
+    if (out_angle == FLT_MAX) {
+        //FIXME Vojtech: Add a warning?
         printf("Using undefined infill angle\n");
         out_angle = 0.f;
     }
@@ -103,7 +103,7 @@ std::pair<float, Point> Fill::_infill_direction(const Surface *surface) const
     // Bounding box is the bounding box of a perl object Slic3r::Print::Object (c++ object Slic3r::PrintObject)
     // The bounding box is only undefined in unit tests.
     Point out_shift = empty(this->bounding_box) ? 
-    	surface->expolygon.contour.bounding_box().center() : 
+        surface->expolygon.contour.bounding_box().center() : 
         this->bounding_box.center();
 
 #if 0
@@ -115,8 +115,8 @@ std::pair<float, Point> Fill::_infill_direction(const Surface *surface) const
 #endif
 
     if (surface->bridge_angle >= 0) {
-	    // use bridge angle
-		//FIXME Vojtech: Add a debugf?
+        // use bridge angle
+        //FIXME Vojtech: Add a debugf?
         // Slic3r::debugf "Filling bridge with angle %d\n", rad2deg($surface->bridge_angle);
 #ifdef SLIC3R_DEBUG
         printf("Filling bridge with angle %f\n", surface->bridge_angle);
@@ -126,7 +126,7 @@ std::pair<float, Point> Fill::_infill_direction(const Surface *surface) const
         // alternate fill direction
         out_angle += this->_layer_angle(this->layer_id / surface->thickness_layers);
     } else {
-//    	printf("Layer_ID undefined!\n");
+//        printf("Layer_ID undefined!\n");
     }
 
     out_angle += float(M_PI/2.);

--- a/xs/src/libslic3r/Fill/FillBase.cpp
+++ b/xs/src/libslic3r/Fill/FillBase.cpp
@@ -23,6 +23,8 @@ Fill* Fill::new_from_type(const InfillPattern type)
     case ipHoneycomb:           return new FillHoneycomb();
     case ip3DHoneycomb:         return new Fill3DHoneycomb();
     case ipGyroid:              return new FillGyroid();
+    case ipGyroidThin:          return new FillGyroidThin();
+    case ipGyroidThick:         return new FillGyroidThick();
     case ipRectilinear:         return new FillRectilinear2();
 //  case ipRectilinear:         return new FillRectilinear();
     case ipSmooth:              return new FillSmooth();

--- a/xs/src/libslic3r/Fill/FillBase.cpp
+++ b/xs/src/libslic3r/Fill/FillBase.cpp
@@ -8,6 +8,7 @@
 #include "FillConcentric.hpp"
 #include "FillHoneycomb.hpp"
 #include "Fill3DHoneycomb.hpp"
+#include "FillGyroid.hpp"
 #include "FillPlanePath.hpp"
 #include "FillRectilinear.hpp"
 #include "FillRectilinear2.hpp"
@@ -21,6 +22,7 @@ Fill* Fill::new_from_type(const InfillPattern type)
     case ipConcentric:          return new FillConcentric();
     case ipHoneycomb:           return new FillHoneycomb();
     case ip3DHoneycomb:         return new Fill3DHoneycomb();
+    case ipGyroid:              return new FillGyroid();
     case ipRectilinear:         return new FillRectilinear2();
 //  case ipRectilinear:         return new FillRectilinear();
     case ipSmooth:              return new FillSmooth();

--- a/xs/src/libslic3r/Fill/FillBase.hpp
+++ b/xs/src/libslic3r/Fill/FillBase.hpp
@@ -81,14 +81,9 @@ public:
     // Perform the fill.
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
 
-    // If this algorithm want to create an ExtrusionEntityCollection instead of a Polylines.
-    virtual bool can_create_extrusion_entity_collection() const { return false; }
     
-    // If canCreateExtrusionEntityCollection return true, this method have to return a correct new ExtrusionEntityCollection.
-    virtual void fill_surface_extrusion(const Surface *surface, 
-    const FillParams &params, 
-    const Flow &flow, 
-    ExtrusionEntityCollection &out ){}
+    // This method have to return a correct new ExtrusionEntityCollection. It call fill_surface by default
+    virtual void fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out );
 
 protected:
     Fill() :

--- a/xs/src/libslic3r/Fill/FillBase.hpp
+++ b/xs/src/libslic3r/Fill/FillBase.hpp
@@ -47,6 +47,8 @@ public:
     size_t      layer_id;
     // Z coordinate of the top print surface, in unscaled coordinates
     coordf_t    z;
+	// For gyroid, to avoid impossible slopes, in unscaled value
+	coordf_t      layer_height;
     // in unscaled coordinates
     coordf_t    spacing;
     // infill / perimeter overlap, in unscaled coordinates

--- a/xs/src/libslic3r/Fill/FillBase.hpp
+++ b/xs/src/libslic3r/Fill/FillBase.hpp
@@ -47,8 +47,8 @@ public:
     size_t      layer_id;
     // Z coordinate of the top print surface, in unscaled coordinates
     coordf_t    z;
-	// For gyroid, to avoid impossible slopes, in unscaled value
-	coordf_t      layer_height;
+    // For gyroid, to avoid impossible slopes, in unscaled value
+    coordf_t      layer_height;
     // in unscaled coordinates
     coordf_t    spacing;
     // infill / perimeter overlap, in unscaled coordinates
@@ -83,12 +83,12 @@ public:
 
     // If this algorithm want to create an ExtrusionEntityCollection instead of a Polylines.
     virtual bool can_create_extrusion_entity_collection() const { return false; }
-	
+    
     // If canCreateExtrusionEntityCollection return true, this method have to return a correct new ExtrusionEntityCollection.
     virtual void fill_surface_extrusion(const Surface *surface, 
-	const FillParams &params, 
-	const Flow &flow, 
-	ExtrusionEntityCollection &out ){}
+    const FillParams &params, 
+    const Flow &flow, 
+    ExtrusionEntityCollection &out ){}
 
 protected:
     Fill() :
@@ -127,8 +127,8 @@ public:
         // for both positive and negative numbers. Here we want to round down for negative
         // numbers as well.
         coord_t aligned = (coord < 0) ?
-        		((coord - spacing + 1) / spacing) * spacing :
-        		(coord / spacing) * spacing;
+                ((coord - spacing + 1) / spacing) * spacing :
+                (coord / spacing) * spacing;
         assert(aligned <= coord);
         return aligned;
     }

--- a/xs/src/libslic3r/Fill/FillBase.hpp
+++ b/xs/src/libslic3r/Fill/FillBase.hpp
@@ -9,6 +9,7 @@
 #include "../libslic3r.h"
 #include "../BoundingBox.hpp"
 #include "../PrintConfig.hpp"
+#include "../Flow.hpp"
 
 namespace Slic3r {
 
@@ -77,6 +78,15 @@ public:
 
     // Perform the fill.
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
+
+    // If this algorithm want to create an ExtrusionEntityCollection instead of a Polylines.
+    virtual bool can_create_extrusion_entity_collection() const { return false; }
+	
+    // If canCreateExtrusionEntityCollection return true, this method have to return a correct new ExtrusionEntityCollection.
+    virtual void fill_surface_extrusion(const Surface *surface, 
+	const FillParams &params, 
+	const Flow &flow, 
+	ExtrusionEntityCollection &out ){}
 
 protected:
     Fill() :

--- a/xs/src/libslic3r/Fill/FillGyroid.cpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.cpp
@@ -79,10 +79,11 @@ static Polylines makeGrid(coord_t gridZ, coord_t gridSize, size_t gridWidth, siz
 	double xPos = 0, yPos=0, width=gridWidth, height=gridHeight;
 	 //scale factor for 5% : 8 712 388
 	 // 1z = 10^-6 mm ?
-	double z = gridZ/(2.0 * scaleFactor);
+	double z = gridZ/(1.0 * scaleFactor);
 	// std::cout<<"gridZ= "<<gridZ<<", z? "<<z<<", scaleFactor= "<<scaleFactor<<", segmentSize= "<<segmentSize<<", decal= "<<decal<<" scale:"<<scale_(1)<<std::endl;
 	double zSn = sin(z);
 	double zCs = cos(z);
+	
 	if(abs(zSn)<=abs(zCs)){
 		//vertical
 		//begin to first one
@@ -139,7 +140,7 @@ static Polylines makeGrid(coord_t gridZ, coord_t gridSize, size_t gridWidth, siz
 		int iter = 1;
 		//search first line output
 		double currentYBegin = yPos ;
-		currentYBegin = PI*(int)(currentYBegin/PI -1);
+		currentYBegin = PI*(int)(currentYBegin/PI -0);
 		iter = (int)(currentYBegin/PI +1)%2;
 		
 		bool flip = iter%2==1;
@@ -147,8 +148,9 @@ static Polylines makeGrid(coord_t gridZ, coord_t gridSize, size_t gridWidth, siz
 		while(currentYBegin < yPos+width){
 
 			if(doubleLine){
-				result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?-decal:decal));
-				Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal:-decal);
+				result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, flip?decal:-decal));
+				
+				Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, flip?-decal:decal);
 				Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
 				wrongOrder.points.assign(temp.begin(),temp.end());
 				result.push_back(wrongOrder);
@@ -163,10 +165,9 @@ static Polylines makeGrid(coord_t gridZ, coord_t gridSize, size_t gridWidth, siz
 			
 			if(currentYBegin<yPos+width){
 				if(doubleLine){
-					//i don't know why i need to *2 ...
-					result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal*2:-decal*2));
+					result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, flip?-decal:decal));
 
-					Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip?-decal*2:decal*2);
+					Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, flip?decal:-decal);
 					Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
 					wrongOrder.points.assign(temp.begin(),temp.end());
 					result.push_back(wrongOrder);
@@ -247,7 +248,7 @@ void FillGyroid::_fill_surface_single(
                 const Point &last_point = pts_end.back();
                 // TODO: we should also check that both points are on a fill_boundary to avoid 
                 // connecting paths on the boundaries of internal regions
-                if (first_point.distance_to(last_point) <= 6 * distance && 
+                if (first_point.distance_to(last_point) <= 4 * distance && 
                     expolygon_off.contains(Line(last_point, first_point))) {
                     // Append the polyline.
                     pts_end.insert(pts_end.end(), it_polyline->points.begin(), it_polyline->points.end());

--- a/xs/src/libslic3r/Fill/FillGyroid.cpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.cpp
@@ -10,68 +10,68 @@
 namespace Slic3r {
 
 Polyline FillGyroid::makeLineVert(double xPos, double yPos, double width, double height, double currentXBegin, double segmentSize, coord_t scaleFactor, 
-		double zCs, double zSn, bool flip, double decal){
-	
-	double maxSlope = abs(abs(zCs)-abs(zSn));
-	Polyline polyline;
-	polyline.points.push_back(Point(coord_t((std::max(std::min(currentXBegin, xPos+width),xPos) + decal) * scaleFactor), coord_t(yPos * scaleFactor)));
-	for(double y=yPos;y<yPos+height+segmentSize;y+=segmentSize){
-		if(y>yPos+height) y = yPos+height;
-		double ySn = sin(y +(zCs<0?3.14:0) + 3.14);
-		double yCs = cos(y +(zCs<0?3.14:0) + 3.14+(!flip?0:3.14));
+        double zCs, double zSn, bool flip, double decal){
+    
+    double maxSlope = abs(abs(zCs)-abs(zSn));
+    Polyline polyline;
+    polyline.points.push_back(Point(coord_t((std::max(std::min(currentXBegin, xPos+width),xPos) + decal) * scaleFactor), coord_t(yPos * scaleFactor)));
+    for(double y=yPos;y<yPos+height+segmentSize;y+=segmentSize){
+        if(y>yPos+height) y = yPos+height;
+        double ySn = sin(y +(zCs<0?3.14:0) + 3.14);
+        double yCs = cos(y +(zCs<0?3.14:0) + 3.14+(!flip?0:3.14));
 
-		double a = ySn;
-		double b = -zCs;
-		double res = zSn*yCs;
-		double r = sqrt(a*a + b*b);
-		double x = asin(a/r) + asin(res/r) +3.14;
-		x += currentXBegin;
+        double a = ySn;
+        double b = -zCs;
+        double res = zSn*yCs;
+        double r = sqrt(a*a + b*b);
+        double x = asin(a/r) + asin(res/r) +3.14;
+        x += currentXBegin;
 
-		if(x < xPos){
-			// needNewLine= true;
-			x = xPos;
-		}
-		if(x > xPos+width){
-			// needNewLine= true;
-			x = xPos+width;
-		}
-		{
-			double ydeviation = 0.5*(flip?-1:1)*(zSn>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
-			polyline.points.push_back(Point(coord_t((x+decal-ydeviation/2) * scaleFactor), coord_t((y + ydeviation) * scaleFactor)));
-		}
-	}
-	
-	return polyline;
+        if(x < xPos){
+            // needNewLine= true;
+            x = xPos;
+        }
+        if(x > xPos+width){
+            // needNewLine= true;
+            x = xPos+width;
+        }
+        {
+            double ydeviation = 0.5*(flip?-1:1)*(zSn>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
+            polyline.points.push_back(Point(coord_t((x+decal-ydeviation/2) * scaleFactor), coord_t((y + ydeviation) * scaleFactor)));
+        }
+    }
+    
+    return polyline;
 }
 
 Polyline FillGyroid::makeLineHori(double xPos, double yPos, double width, double height, double currentYBegin, double segmentSize, coord_t scaleFactor, 
-		double zCs, double zSn, bool flip, double decal){
-	double maxSlope = abs(abs(zCs)-abs(zSn));
-	Polyline polyline;
-	polyline.points.push_back(Point(coord_t(xPos * scaleFactor), coord_t((std::max(std::min(currentYBegin, yPos+height),yPos)+decal) * scaleFactor)));
-	for(double x=xPos;x<xPos+width+segmentSize;x+=segmentSize){
-		if(x>xPos+width) x = xPos+width;
-		double xSn = sin(x +(zSn<0?3.14:0) +(flip?0:3.14));
-		double xCs = cos(x +(zSn<0?3.14:0) );
-		double a = xCs;
-		double b = -zSn;
-		double res = zCs*xSn;
-		double r = sqrt(a*a + b*b);
-		double y = asin(a/r) + asin(res/r) +3.14/2;
-		y += currentYBegin;
-		double xdeviation = 0.5*(flip?-1:1)*(zCs>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
-		polyline.points.push_back(Point(coord_t((x + xdeviation) * scaleFactor), coord_t((std::max(std::min(y, yPos+height),yPos)+decal-xdeviation/2) * scaleFactor)));
-	}
-	
-	return polyline;
+        double zCs, double zSn, bool flip, double decal){
+    double maxSlope = abs(abs(zCs)-abs(zSn));
+    Polyline polyline;
+    polyline.points.push_back(Point(coord_t(xPos * scaleFactor), coord_t((std::max(std::min(currentYBegin, yPos+height),yPos)+decal) * scaleFactor)));
+    for(double x=xPos;x<xPos+width+segmentSize;x+=segmentSize){
+        if(x>xPos+width) x = xPos+width;
+        double xSn = sin(x +(zSn<0?3.14:0) +(flip?0:3.14));
+        double xCs = cos(x +(zSn<0?3.14:0) );
+        double a = xCs;
+        double b = -zSn;
+        double res = zCs*xSn;
+        double r = sqrt(a*a + b*b);
+        double y = asin(a/r) + asin(res/r) +3.14/2;
+        y += currentYBegin;
+        double xdeviation = 0.5*(flip?-1:1)*(zCs>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
+        polyline.points.push_back(Point(coord_t((x + xdeviation) * scaleFactor), coord_t((std::max(std::min(y, yPos+height),yPos)+decal-xdeviation/2) * scaleFactor)));
+    }
+    
+    return polyline;
 }
 
 inline void FillGyroid::correctOrderAndAdd(const int num, Polyline &poly, Polylines &array){
-	if(num%2==0){
-		Points temp(poly.points.rbegin(), poly.points.rend());
-		poly.points.assign(temp.begin(),temp.end());
-	}
-	array.push_back(poly);
+    if(num%2==0){
+        Points temp(poly.points.rbegin(), poly.points.rend());
+        poly.points.assign(temp.begin(),temp.end());
+    }
+    array.push_back(poly);
 }
 
 // Generate a set of curves (array of array of 2d points) that describe a
@@ -79,135 +79,135 @@ inline void FillGyroid::correctOrderAndAdd(const int num, Polyline &poly, Polyli
 // grid square size.
 Polylines FillGyroid::makeGrid(coord_t gridZ, double density, double layer_width, double layer_height, size_t gridWidth, size_t gridHeight, size_t curveType)
 {
-	
+    
     coord_t  scaleFactor = coord_t(scale_(layer_width) / density);
     Polylines result;
-	Polyline *polyline2;
-	double segmentSize = density/2;
-	double decal = layer_width*density;
-	double xPos = 0, yPos=0, width=gridWidth, height=gridHeight;
-	 //scale factor for 5% : 8 712 388
-	 // 1z = 10^-6 mm ?
-	double z = gridZ/(1.0 * scaleFactor);
-	// std::cout<<"gridZ= "<<gridZ<<", z? "<<z<<", scaleFactor= "<<scaleFactor<<", segmentSize= "<<segmentSize<<", decal= "<<decal<<" scale:"<<scale_(1)<<std::endl;
-	double zSn = sin(z);
-	double zCs = cos(z);
-	double maxSlope = abs(abs(zCs)-abs(zSn));
-	//be sure to don't be too near each other)
-	while(maxSlope<0.05){
-		// move away
-		bool sameSign = zCs*zSn>=0;
-		bool absCosGtAbsSin = abs(zCs)>abs(zSn);
-		if(sameSign && !absCosGtAbsSin || !sameSign && absCosGtAbsSin){
-			// then add
-			z += 0.001;
-		}else{
-			// then remove
-			z -= 0.001;
-		}
-		zSn = sin(z);
-		zCs = cos(z);
-		maxSlope = abs(abs(zCs)-abs(zSn));
-		for(int i=0;i<100000000;i++){i%2==0?density+=0.001:density-=0.001;}
-	}
-	
+    Polyline *polyline2;
+    double segmentSize = density/2;
+    double decal = layer_width*density;
+    double xPos = 0, yPos=0, width=gridWidth, height=gridHeight;
+     //scale factor for 5% : 8 712 388
+     // 1z = 10^-6 mm ?
+    double z = gridZ/(1.0 * scaleFactor);
+    // std::cout<<"gridZ= "<<gridZ<<", z? "<<z<<", scaleFactor= "<<scaleFactor<<", segmentSize= "<<segmentSize<<", decal= "<<decal<<" scale:"<<scale_(1)<<std::endl;
+    double zSn = sin(z);
+    double zCs = cos(z);
+    double maxSlope = abs(abs(zCs)-abs(zSn));
+    //be sure to don't be too near each other)
+    while(maxSlope<0.05){
+        // move away
+        bool sameSign = zCs*zSn>=0;
+        bool absCosGtAbsSin = abs(zCs)>abs(zSn);
+        if(sameSign && !absCosGtAbsSin || !sameSign && absCosGtAbsSin){
+            // then add
+            z += 0.001;
+        }else{
+            // then remove
+            z -= 0.001;
+        }
+        zSn = sin(z);
+        zCs = cos(z);
+        maxSlope = abs(abs(zCs)-abs(zSn));
+        for(int i=0;i<100000000;i++){i%2==0?density+=0.001:density-=0.001;}
+    }
+    
 
-	int numLine = 0;
-	//nbLines depends of layer_width, layer_height, density and maxSlope 
-	int nbLines = wall_nb_lines;
-	if(wall_nb_lines<=0){
-		if(density>0.6){
-			nbLines = 2;
-		}else{
-			//compute the coverage of the current layer
-			double nbLineMore = 1 + (1 - maxSlope);
-			nbLineMore = pow(nbLineMore,5);
-			nbLineMore = nbLineMore -1;
-			nbLineMore *= 0.1 * layer_height / (layer_width * sqrt(density));
-			nbLines = (int)(nbLineMore - wall_nb_lines);
-			// std::cout<<"|maxSlope="<<maxSlope<<"; nbLineMore= "<<nbLineMore<<std::endl;
-		}
-	}
-	
-	if(abs(zSn)<=abs(zCs)){
-		//vertical
-		//begin to first one
-		int iter = 1;
-		double currentXBegin = xPos - PI/2;
-		currentXBegin = PI*(int)(currentXBegin/PI -1);
-		iter = (int)(currentXBegin/PI +1)%2;
-		bool flip = iter%2==1;
-		// bool needNewLine =false;
-		while(currentXBegin<xPos+width-PI/2){
-			
-			for(int num=0;num<nbLines;num++){
-				double movex = -decal * (nbLines-1) + num*decal*2;
-				correctOrderAndAdd(numLine, makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
-				numLine++;
-			}
-			
-			//then, return by the other side
-			iter++;
-			currentXBegin = currentXBegin + PI;
-			flip = iter%2==1;
-			
-			if(currentXBegin < xPos+width-PI/2){
-				
-				for(int num=0;num<nbLines;num++){
-					double movex = -decal * (nbLines-1) + num*decal*2;
-					correctOrderAndAdd(numLine, makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
-					numLine++;
-				}
+    int numLine = 0;
+    //nbLines depends of layer_width, layer_height, density and maxSlope 
+    int nbLines = wall_nb_lines;
+    if(wall_nb_lines<=0){
+        if(density>0.6){
+            nbLines = 2;
+        }else{
+            //compute the coverage of the current layer
+            double nbLineMore = 1 + (1 - maxSlope);
+            nbLineMore = pow(nbLineMore,5);
+            nbLineMore = nbLineMore -1;
+            nbLineMore *= 0.1 * layer_height / (layer_width * sqrt(density));
+            nbLines = (int)(nbLineMore - wall_nb_lines);
+            // std::cout<<"|maxSlope="<<maxSlope<<"; nbLineMore= "<<nbLineMore<<std::endl;
+        }
+    }
+    
+    if(abs(zSn)<=abs(zCs)){
+        //vertical
+        //begin to first one
+        int iter = 1;
+        double currentXBegin = xPos - PI/2;
+        currentXBegin = PI*(int)(currentXBegin/PI -1);
+        iter = (int)(currentXBegin/PI +1)%2;
+        bool flip = iter%2==1;
+        // bool needNewLine =false;
+        while(currentXBegin<xPos+width-PI/2){
+            
+            for(int num=0;num<nbLines;num++){
+                double movex = -decal * (nbLines-1) + num*decal*2;
+                correctOrderAndAdd(numLine, makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
+                numLine++;
+            }
+            
+            //then, return by the other side
+            iter++;
+            currentXBegin = currentXBegin + PI;
+            flip = iter%2==1;
+            
+            if(currentXBegin < xPos+width-PI/2){
+                
+                for(int num=0;num<nbLines;num++){
+                    double movex = -decal * (nbLines-1) + num*decal*2;
+                    correctOrderAndAdd(numLine, makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
+                    numLine++;
+                }
 
-				// relance
-				iter++;
-				currentXBegin = currentXBegin + PI;
-				flip = iter%2==1;
-			}
-		}
-	}else{
-		//horizontal
-		
+                // relance
+                iter++;
+                currentXBegin = currentXBegin + PI;
+                flip = iter%2==1;
+            }
+        }
+    }else{
+        //horizontal
+        
 
-		//begin to first one
-		int iter = 1;
-		//search first line output
-		double currentYBegin = yPos ;
-		currentYBegin = PI*(int)(currentYBegin/PI -0);
-		iter = (int)(currentYBegin/PI +1)%2;
-		
-		bool flip = iter%2==1;
-		
-		
-		while(currentYBegin < yPos+width){
+        //begin to first one
+        int iter = 1;
+        //search first line output
+        double currentYBegin = yPos ;
+        currentYBegin = PI*(int)(currentYBegin/PI -0);
+        iter = (int)(currentYBegin/PI +1)%2;
+        
+        bool flip = iter%2==1;
+        
+        
+        while(currentYBegin < yPos+width){
 
-			for(int num=0;num<nbLines;num++){
-				double movex = -decal * (nbLines-1) + num*decal*2;
-				correctOrderAndAdd(numLine, makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
-				numLine++;
-			}
-		
-			//then, return by the other side
-			iter++;
-			currentYBegin = currentYBegin + PI;
-			flip = iter%2==1;
-			
-			if(currentYBegin<yPos+width){
-				
-				for(int num=0;num<nbLines;num++){
-					double movex = -decal * (nbLines-1) + num*decal*2;
-					correctOrderAndAdd(numLine, makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
-					numLine++;
-				}
-				
-				//relance
-				iter++;
-				currentYBegin = currentYBegin + PI;
-				flip = iter%2==1;
-			}
-		}
-	}
-	
+            for(int num=0;num<nbLines;num++){
+                double movex = -decal * (nbLines-1) + num*decal*2;
+                correctOrderAndAdd(numLine, makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
+                numLine++;
+            }
+        
+            //then, return by the other side
+            iter++;
+            currentYBegin = currentYBegin + PI;
+            flip = iter%2==1;
+            
+            if(currentYBegin<yPos+width){
+                
+                for(int num=0;num<nbLines;num++){
+                    double movex = -decal * (nbLines-1) + num*decal*2;
+                    correctOrderAndAdd(numLine, makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip, movex), result);
+                    numLine++;
+                }
+                
+                //relance
+                iter++;
+                currentYBegin = currentYBegin + PI;
+                flip = iter%2==1;
+            }
+        }
+    }
+    
     return result;
 }
 
@@ -222,7 +222,7 @@ void FillGyroid::_fill_surface_single(
     BoundingBox bb = expolygon.contour.bounding_box();
     coord_t     distance = coord_t(scale_(this->spacing) / (params.density*scaling));
 
-	// align bounding box to a multiple of our grid module
+    // align bounding box to a multiple of our grid module
     bb.merge(_align_to_grid(bb.min, Point(2*M_PI*distance, 2*M_PI*distance)));
     
     // generate pattern
@@ -230,7 +230,7 @@ void FillGyroid::_fill_surface_single(
         (coord_t)scale_(this->z),
         params.density*scaling,
         this->spacing,
-		this->layer_height,
+        this->layer_height,
         (size_t)(ceil(bb.size().x / distance) + 1),
         (size_t)(ceil(bb.size().y / distance) + 1),
         (size_t)(((this->layer_id/thickness_layers) % 2) + 1) );
@@ -238,7 +238,7 @@ void FillGyroid::_fill_surface_single(
     // move pattern in place
     for (Polylines::iterator it = polylines.begin(); it != polylines.end(); ++ it)
         it->translate(bb.min.x, bb.min.y);
-	
+    
 
     // clip pattern to boundaries
     polylines = intersection_pl(polylines, (Polygons)expolygon);
@@ -270,8 +270,8 @@ void FillGyroid::_fill_surface_single(
                 const Point &last_point = pts_end.back();
                 // TODO: we should also check that both points are on a fill_boundary to avoid 
                 // connecting paths on the boundaries of internal regions
-				// TODO: avoid crossing current infill path, a bug somewhere?
-				if (first_point.distance_to(last_point) <= 5 * distance && 
+                // TODO: avoid crossing current infill path, a bug somewhere?
+                if (first_point.distance_to(last_point) <= 5 * distance && 
                     expolygon_off.contains(Line(last_point, first_point))) {
                     // Append the polyline.
                     pts_end.insert(pts_end.end(), it_polyline->points.begin(), it_polyline->points.end());

--- a/xs/src/libslic3r/Fill/FillGyroid.cpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.cpp
@@ -39,8 +39,8 @@ static Polyline makeLineVert(double xPos, double yPos, double width, double heig
 			x = xPos+width;
 		}
 		{
-			double ydeviation = (flip?-1:1)*(zSn>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
-			polyline.points.push_back(Point(coord_t((x+decal) * scaleFactor), coord_t((y + ydeviation) * scaleFactor)));
+			double ydeviation = 0.5*(flip?-1:1)*(zSn>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
+			polyline.points.push_back(Point(coord_t((x+decal-ydeviation/2) * scaleFactor), coord_t((y + ydeviation) * scaleFactor)));
 		}
 	}
 	
@@ -61,8 +61,8 @@ static Polyline makeLineHori(double xPos, double yPos, double width, double heig
 		double r = sqrt(a*a + b*b);
 		double y = asin(a/r) + asin(res/r) +3.14/2;
 		y += currentYBegin;
-		double xdeviation = (flip?-1:1)*(zCs>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
-		polyline.points.push_back(Point(coord_t((x + xdeviation) * scaleFactor), coord_t((std::max(std::min(y, yPos+height),yPos)+decal) * scaleFactor)));
+		double xdeviation = 0.5*(flip?-1:1)*(zCs>0?-1:1)*decal*(1-maxSlope)*(res/r - a/r);
+		polyline.points.push_back(Point(coord_t((x + xdeviation) * scaleFactor), coord_t((std::max(std::min(y, yPos+height),yPos)+decal-xdeviation/2) * scaleFactor)));
 	}
 	
 	return polyline;

--- a/xs/src/libslic3r/Fill/FillGyroid.cpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.cpp
@@ -1,0 +1,269 @@
+#include "../ClipperUtils.hpp"
+#include "../PolylineCollection.hpp"
+#include "../Surface.hpp"
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+
+#include "FillGyroid.hpp"
+
+namespace Slic3r {
+
+
+static double const doubleLine = true;
+
+static Polyline makeLineVert(double xPos, double yPos, double width, double height, double currentXBegin, double segmentSize, coord_t scaleFactor, double zCs, double zSn, bool flip, double decal=0){
+	
+	Polyline polyline;
+	polyline.points.push_back(Point(coord_t((std::max(std::min(currentXBegin, xPos+width),xPos) + decal) * scaleFactor), coord_t(yPos * scaleFactor)));
+	for(double y=yPos;y<yPos+height+segmentSize;y+=segmentSize){
+		if(y>yPos+height) y = yPos+height;
+		double ySn = sin(y +(zCs<0?3.14:0) + 3.14);
+		double yCs = cos(y +(zCs<0?3.14:0) + 3.14+(!flip?0:3.14));
+
+		double a = ySn;
+		double b = -zCs;
+		double res = zSn*yCs;
+		double r = sqrt(a*a + b*b);
+		double x = asin(a/r) + asin(res/r) +3.14;
+		x += currentXBegin;
+
+		if(x < xPos){
+			// needNewLine= true;
+			x = xPos;
+		}
+		if(x > xPos+width){
+			// needNewLine= true;
+			x = xPos+width;
+		}
+		{
+			polyline.points.push_back(Point(coord_t((x+decal) * scaleFactor), coord_t(y * scaleFactor)));
+		}
+	}
+	
+	return polyline;
+}
+
+static Polyline makeLineHori(double xPos, double yPos, double width, double height, double currentYBegin, double segmentSize, coord_t scaleFactor, double zCs, double zSn, bool flip, double decal=0){
+	Polyline polyline;
+	polyline.points.push_back(Point(coord_t(xPos * scaleFactor), coord_t((std::max(std::min(currentYBegin, yPos+height),yPos)+decal) * scaleFactor)));
+	for(double x=xPos;x<xPos+width+segmentSize;x+=segmentSize){
+		if(x>xPos+width) x = xPos+width;
+		double xSn = sin(x +(zSn<0?3.14:0) +(flip?0:3.14));
+		double xCs = cos(x +(zSn<0?3.14:0) );
+
+		double a = xCs;
+		double b = -zSn;
+		double res = zCs*xSn;
+		double r = sqrt(a*a + b*b);
+		double y = asin(a/r) + asin(res/r) +3.14/2;
+		y += currentYBegin;
+		polyline.points.push_back(Point(coord_t(x * scaleFactor), coord_t((std::max(std::min(y, yPos+height),yPos)+decal) * scaleFactor)));
+	}
+	
+	return polyline;
+}
+
+// Generate a set of curves (array of array of 2d points) that describe a
+// horizontal slice of a truncated regular octahedron with a specified
+// grid square size.
+static Polylines makeGrid(coord_t gridZ, coord_t gridSize, size_t gridWidth, size_t gridHeight, size_t curveType)
+{
+	//TODO: reverse order 1layer/2 to change the "wall" for the other side
+	
+    coord_t  scaleFactor = gridSize;
+    Polylines result;
+	Polyline *polyline2;
+	double segmentSize = 871238.0 / scaleFactor; //871238
+	double decal = 8712380.0 / (scaleFactor*40);
+	double xPos = 0, yPos=0, width=gridWidth, height=gridHeight;
+	 //scale factor for 5% : 8 712 388
+	 // 1z = 10^-6 mm ?
+	double z = gridZ/(2.0 * scaleFactor);
+	// std::cout<<"gridZ= "<<gridZ<<", z? "<<z<<", scaleFactor= "<<scaleFactor<<", segmentSize= "<<segmentSize<<", decal= "<<decal<<" scale:"<<scale_(1)<<std::endl;
+	double zSn = sin(z);
+	double zCs = cos(z);
+	if(abs(zSn)<=abs(zCs)){
+		//vertical
+		//begin to first one
+		int iter = 1;
+		double currentXBegin = xPos - PI/2;
+		currentXBegin = PI*(int)(currentXBegin/PI -1);
+		iter = (int)(currentXBegin/PI +1)%2;
+		bool flip = iter%2==1;
+		// bool needNewLine =false;
+		while(currentXBegin<xPos+width-PI/2){
+			
+			
+			if(doubleLine){
+				result.push_back(makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?-decal:decal));
+				Polyline wrongOrder = makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal:-decal);
+				Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+				wrongOrder.points.assign(temp.begin(),temp.end());
+				result.push_back(wrongOrder);
+			}else{
+				result.push_back(makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip));
+			}
+			
+			//then, return by the other side
+			iter++;
+			currentXBegin = currentXBegin + PI;
+			flip = iter%2==1;
+			
+			if(currentXBegin < xPos+width-PI/2){
+				if(doubleLine){
+					result.push_back(makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal:-decal));
+					Polyline wrongOrder = makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?-decal:decal);
+					Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+					wrongOrder.points.assign(temp.begin(),temp.end());
+					result.push_back(wrongOrder);
+				}else{
+				
+					Polyline wrongOrder = makeLineVert(xPos, yPos, width, height, currentXBegin, segmentSize, scaleFactor, zCs, zSn, flip);
+					Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+					wrongOrder.points.assign(temp.begin(),temp.end());
+					result.push_back(wrongOrder);
+				}
+				
+				// //relance
+				iter++;
+				currentXBegin = currentXBegin + PI;
+				flip = iter%2==1;
+			}
+		}
+	}else{
+		//horizontal
+		
+
+		//begin to first one
+		int iter = 1;
+		//search first line output
+		double currentYBegin = yPos ;
+		currentYBegin = PI*(int)(currentYBegin/PI -1);
+		iter = (int)(currentYBegin/PI +1)%2;
+		
+		bool flip = iter%2==1;
+		
+		while(currentYBegin < yPos+width){
+
+			if(doubleLine){
+				result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?-decal:decal));
+				Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal:-decal);
+				Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+				wrongOrder.points.assign(temp.begin(),temp.end());
+				result.push_back(wrongOrder);
+			}else{
+				result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip));
+			}
+
+			//then, return by the other side
+			iter++;
+			currentYBegin = currentYBegin + PI;
+			flip = iter%2==1;
+			
+			if(currentYBegin<yPos+width){
+				if(doubleLine){
+					//i don't know why i need to *2 ...
+					result.push_back(makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip,flip?decal*2:-decal*2));
+
+					Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip?-decal*2:decal*2);
+					Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+					wrongOrder.points.assign(temp.begin(),temp.end());
+					result.push_back(wrongOrder);
+				}else{
+
+					Polyline wrongOrder = makeLineHori(xPos, yPos, width, height, currentYBegin, segmentSize, scaleFactor, zCs, zSn, flip);
+					Points temp(wrongOrder.points.rbegin(), wrongOrder.points.rend());
+					wrongOrder.points.assign(temp.begin(),temp.end());
+					result.push_back(wrongOrder);
+				}
+				
+				//relance
+				iter++;
+				currentYBegin = currentYBegin + PI;
+				flip = iter%2==1;
+			}
+		}
+	}
+	
+    return result;
+}
+
+void FillGyroid::_fill_surface_single(
+    const FillParams                &params, 
+    unsigned int                     thickness_layers,
+    const std::pair<float, Point>   &direction, 
+    ExPolygon                       &expolygon, 
+    Polylines                       &polylines_out)
+{
+    // no rotation is supported for this infill pattern
+    BoundingBox bb = expolygon.contour.bounding_box();
+    coord_t     distance = coord_t(scale_(this->spacing) / params.density);
+
+    // align bounding box to a multiple of our honeycomb grid module
+    // (a module is 2*$distance since one $distance half-module is 
+    // growing while the other $distance half-module is shrinking)
+    bb.merge(_align_to_grid(bb.min, Point(2*distance, 2*distance)));
+    
+    // generate pattern
+    Polylines   polylines = makeGrid(
+        scale_(this->z),
+        distance,
+        ceil(bb.size().x / distance) + 1,
+        ceil(bb.size().y / distance) + 1,
+        ((this->layer_id/thickness_layers) % 2) + 1);
+    
+    // move pattern in place
+    for (Polylines::iterator it = polylines.begin(); it != polylines.end(); ++ it)
+        it->translate(bb.min.x, bb.min.y);
+
+    // clip pattern to boundaries
+    polylines = intersection_pl(polylines, (Polygons)expolygon);
+
+    // connect lines
+    if (! params.dont_connect && ! polylines.empty()) { // prevent calling leftmost_point() on empty collections
+        ExPolygon expolygon_off;
+        {
+            ExPolygons expolygons_off = offset_ex(expolygon, SCALED_EPSILON);
+            if (! expolygons_off.empty()) {
+                // When expanding a polygon, the number of islands could only shrink. Therefore the offset_ex shall generate exactly one expanded island for one input island.
+                assert(expolygons_off.size() == 1);
+                std::swap(expolygon_off, expolygons_off.front());
+            }
+        }
+        Polylines chained = PolylineCollection::chained_path_from(
+#if SLIC3R_CPPVER >= 11
+            std::move(polylines), 
+#else
+            polylines,
+#endif
+            PolylineCollection::leftmost_point(polylines), false); // reverse allowed
+        bool first = true;
+        for (Polylines::iterator it_polyline = chained.begin(); it_polyline != chained.end(); ++ it_polyline) {
+            if (! first) {
+                // Try to connect the lines.
+                Points &pts_end = polylines_out.back().points;
+                const Point &first_point = it_polyline->points.front();
+                const Point &last_point = pts_end.back();
+                // TODO: we should also check that both points are on a fill_boundary to avoid 
+                // connecting paths on the boundaries of internal regions
+                if (first_point.distance_to(last_point) <= 6 * distance && 
+                    expolygon_off.contains(Line(last_point, first_point))) {
+                    // Append the polyline.
+                    pts_end.insert(pts_end.end(), it_polyline->points.begin(), it_polyline->points.end());
+                    continue;
+                }
+            }
+            // The lines cannot be connected.
+#if SLIC3R_CPPVER >= 11
+            polylines_out.push_back(std::move(*it_polyline));
+#else
+            polylines_out.push_back(Polyline());
+            std::swap(polylines_out.back(), *it_polyline);
+#endif
+            first = false;
+        }
+    }
+}
+
+} // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillGyroid.hpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.hpp
@@ -13,44 +13,44 @@ class FillGyroid : public Fill
 {
 public:
 
-	FillGyroid(){ wall_nb_lines = -1; scaling = 1.12f; }
+    FillGyroid(){ wall_nb_lines = -1; scaling = 1.12f; }
     virtual Fill* clone() const { return new FillGyroid(*this); };
     virtual ~FillGyroid() {}
 
-	// require bridge flow since most of this pattern hangs in air
+    // require bridge flow since most of this pattern hangs in air
     virtual bool use_bridge_flow() const { return true; }
 
 protected:
 
-	// 0 = auto (from 0 to ~4).
-	//neg : auto whit min = -GYROID_WALL_NB_LINES
-	//  note: if not -2, the density is not properly calculated anymore.
-	int wall_nb_lines;
-	
-	float scaling;
+    // 0 = auto (from 0 to ~4).
+    //neg : auto whit min = -GYROID_WALL_NB_LINES
+    //  note: if not -2, the density is not properly calculated anymore.
+    int wall_nb_lines;
+    
+    float scaling;
 
 
-	virtual void _fill_surface_single(
-	    const FillParams                &params, 
-	    unsigned int                     thickness_layers,
-	    const std::pair<float, Point>   &direction, 
-	    ExPolygon                       &expolygon, 
-	    Polylines                       &polylines_out);
-	
-	// create the gyroid grid to clip.
-	Polylines makeGrid(coord_t gridZ, double density, double layer_width, double layer_height, size_t gridWidth, size_t gridHeight, size_t curveType);
-	//add line poly in reverse if needed into array
-	inline void correctOrderAndAdd(const int num, Polyline &poly, Polylines &array);
-	//create a curved horinzontal line  (for each x, compute y)
-	Polyline makeLineHori(double xPos, double yPos, double width, double height, 
-		double currentYBegin, double segmentSize, coord_t scaleFactor, 
-		double zCs, double zSn, 
-		bool flip, double decal=0);
-	//create a curved vertival line (for each y, compute x)
-	Polyline makeLineVert(double xPos, double yPos, double width, double height, 
-		double currentXBegin, double segmentSize, coord_t scaleFactor, 
-		double zCs, double zSn, 
-		bool flip, double decal=0);
+    virtual void _fill_surface_single(
+        const FillParams                &params, 
+        unsigned int                     thickness_layers,
+        const std::pair<float, Point>   &direction, 
+        ExPolygon                       &expolygon, 
+        Polylines                       &polylines_out);
+    
+    // create the gyroid grid to clip.
+    Polylines makeGrid(coord_t gridZ, double density, double layer_width, double layer_height, size_t gridWidth, size_t gridHeight, size_t curveType);
+    //add line poly in reverse if needed into array
+    inline void correctOrderAndAdd(const int num, Polyline &poly, Polylines &array);
+    //create a curved horinzontal line  (for each x, compute y)
+    Polyline makeLineHori(double xPos, double yPos, double width, double height, 
+        double currentYBegin, double segmentSize, coord_t scaleFactor, 
+        double zCs, double zSn, 
+        bool flip, double decal=0);
+    //create a curved vertival line (for each y, compute x)
+    Polyline makeLineVert(double xPos, double yPos, double width, double height, 
+        double currentXBegin, double segmentSize, coord_t scaleFactor, 
+        double zCs, double zSn, 
+        bool flip, double decal=0);
 
 };
 
@@ -58,7 +58,7 @@ protected:
 class FillGyroidThin : public FillGyroid
 {
 public:
-	FillGyroidThin(){ wall_nb_lines = 1; scaling = 1.75; }
+    FillGyroidThin(){ wall_nb_lines = 1; scaling = 1.75; }
     virtual Fill* clone() const { return new FillGyroidThin(*this); };
     virtual ~FillGyroidThin() {}
 
@@ -67,7 +67,7 @@ public:
 class FillGyroidThick : public FillGyroid
 {
 public:
-	FillGyroidThick(){ wall_nb_lines = -2; scaling = 0.59f; }
+    FillGyroidThick(){ wall_nb_lines = -2; scaling = 0.59f; }
     virtual Fill* clone() const { return new FillGyroidThick(*this); };
     virtual ~FillGyroidThick() {}
 

--- a/xs/src/libslic3r/Fill/FillGyroid.hpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.hpp
@@ -1,0 +1,32 @@
+#ifndef slic3r_FillGyroid_hpp_
+#define slic3r_FillGyroid_hpp_
+
+#include <map>
+
+#include "../libslic3r.h"
+
+#include "FillBase.hpp"
+
+namespace Slic3r {
+
+class FillGyroid : public Fill
+{
+public:
+    virtual Fill* clone() const { return new FillGyroid(*this); };
+    virtual ~FillGyroid() {}
+
+	// require bridge flow since most of this pattern hangs in air
+    virtual bool use_bridge_flow() const { return true; }
+
+protected:
+	virtual void _fill_surface_single(
+	    const FillParams                &params, 
+	    unsigned int                     thickness_layers,
+	    const std::pair<float, Point>   &direction, 
+	    ExPolygon                       &expolygon, 
+	    Polylines                       &polylines_out);
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_FillGyroid_hpp_

--- a/xs/src/libslic3r/Fill/FillGyroid.hpp
+++ b/xs/src/libslic3r/Fill/FillGyroid.hpp
@@ -12,6 +12,8 @@ namespace Slic3r {
 class FillGyroid : public Fill
 {
 public:
+
+	FillGyroid(){ wall_nb_lines = -1; scaling = 1.12f; }
     virtual Fill* clone() const { return new FillGyroid(*this); };
     virtual ~FillGyroid() {}
 
@@ -19,12 +21,56 @@ public:
     virtual bool use_bridge_flow() const { return true; }
 
 protected:
+
+	// 0 = auto (from 0 to ~4).
+	//neg : auto whit min = -GYROID_WALL_NB_LINES
+	//  note: if not -2, the density is not properly calculated anymore.
+	int wall_nb_lines;
+	
+	float scaling;
+
+
 	virtual void _fill_surface_single(
 	    const FillParams                &params, 
 	    unsigned int                     thickness_layers,
 	    const std::pair<float, Point>   &direction, 
 	    ExPolygon                       &expolygon, 
 	    Polylines                       &polylines_out);
+	
+	// create the gyroid grid to clip.
+	Polylines makeGrid(coord_t gridZ, double density, double layer_width, double layer_height, size_t gridWidth, size_t gridHeight, size_t curveType);
+	//add line poly in reverse if needed into array
+	inline void correctOrderAndAdd(const int num, Polyline &poly, Polylines &array);
+	//create a curved horinzontal line  (for each x, compute y)
+	Polyline makeLineHori(double xPos, double yPos, double width, double height, 
+		double currentYBegin, double segmentSize, coord_t scaleFactor, 
+		double zCs, double zSn, 
+		bool flip, double decal=0);
+	//create a curved vertival line (for each y, compute x)
+	Polyline makeLineVert(double xPos, double yPos, double width, double height, 
+		double currentXBegin, double segmentSize, coord_t scaleFactor, 
+		double zCs, double zSn, 
+		bool flip, double decal=0);
+
+};
+
+
+class FillGyroidThin : public FillGyroid
+{
+public:
+	FillGyroidThin(){ wall_nb_lines = 1; scaling = 1.75; }
+    virtual Fill* clone() const { return new FillGyroidThin(*this); };
+    virtual ~FillGyroidThin() {}
+
+};
+
+class FillGyroidThick : public FillGyroid
+{
+public:
+	FillGyroidThick(){ wall_nb_lines = -2; scaling = 0.59f; }
+    virtual Fill* clone() const { return new FillGyroidThick(*this); };
+    virtual ~FillGyroidThick() {}
+
 };
 
 } // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -1483,48 +1483,48 @@ Polylines FillSmooth::fill_surface(const Surface *surface, const FillParams &par
 }
 void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out )
 {
-    // Each linear fill covers 1/3 of the target coverage.
+	//second pass with half layer width
     FillParams params2 = params;
     params2.density *= 2.0f;
     Polylines polylines_out;
     Polylines polylines_outNoExtrud;
-    if (! fill_surface_by_lines(surface, params, 0.f, 0., polylines_out) ||
-        ! fill_surface_by_lines(surface, params2, float(M_PI/2), 0., polylines_outNoExtrud)) {
-        printf("FillCubic::fill_surface() failed to fill a region.\n");
+    if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
+        ! fill_surface_by_lines(surface, params2, float(M_PI/2), 0.f, polylines_outNoExtrud)) {
+        printf("FillSmooth::fill_surface() failed to fill a region.\n");
     } 
 	
 	if (polylines_out.empty())
 		return;
 	
-	Flow tempFlow = Flow::new_from_spacing(spacing, flow.nozzle_diameter, flow.height, flow.bridge || use_bridge_flow());
+	// Flow tempFlow = flow;
 	
-	float stdflowWidth = tempFlow.width;
+	ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
+	out.entities.push_back(eecroot);
+	eecroot->no_sort = true;
 	
+	// float stdflowWidth = tempFlow.width;
 	// Save into layer.
 	ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
-	out.entities.push_back(eec);
-	// Only concentric fills are not sorted.
-	eec->no_sort = no_sort();
-	tempFlow.width = stdflowWidth * 1.8f; // print almost 100% (90%)
+	eecroot->entities.push_back(eec);
+	// tempFlow.width = stdflowWidth * 0.9f; // print almost 100% (90%)
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_out),
-		tempFlow.bridge ?
+		flow.bridge ?
 			erBridgeInfill :
 			(surface->is_solid() ?
 				((surface->surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
 				erInternalInfill),
-		tempFlow.mm3_per_mm(), tempFlow.width, tempFlow.height);
+		flow.mm3_per_mm()*0.95, flow.width*0.95, flow.height);
 		
 	// Save into layer smoothing path.
 	eec = new ExtrusionEntityCollection();
-	out.entities.push_back(eec);
-	// Only concentric fills are not sorted.
-	eec->no_sort = no_sort();
-	tempFlow.width = stdflowWidth * 0.05f; //print the last 10% (with 2 times more lines) -> gapfill
+	eecroot->entities.push_back(eec);
+	// tempFlow.width = stdflowWidth * 0.05f; //print the last 10% (with 2 times more lines) -> gapfill
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_outNoExtrud),
-		erNone, //speedy (or use erInternalInfill)
-		tempFlow.mm3_per_mm(), tempFlow.width, tempFlow.height);
+		erInternalInfill, //speedy (or use erInternalInfill, erNone)
+		flow.mm3_per_mm()*0.15, flow.width*0.15, flow.height);
+	// std::cout<<"std : flow"<<(flow.mm3_per_mm()*0.2)<<", width"<<(flow.width*0.2)<<", height"<<(flow.height)<<"\n";
 }
 
 } // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -296,13 +296,13 @@ public:
         polygons_inner = offset(polygons_outer, aoffset2 - aoffset1,
             ClipperLib::jtMiter,
             mitterLimit);
-		// Filter out contours with zero area or small area, contours with 2 points only.
+        // Filter out contours with zero area or small area, contours with 2 points only.
         const double min_area_threshold = 0.01 * aoffset2 * aoffset2;
         remove_small(polygons_outer, min_area_threshold);
         remove_small(polygons_inner, min_area_threshold);
         remove_sticks(polygons_outer);
         remove_sticks(polygons_inner);
-		n_contours_outer = polygons_outer.size();
+        n_contours_outer = polygons_outer.size();
         n_contours_inner = polygons_inner.size();
         n_contours = n_contours_outer + n_contours_inner;
         polygons_ccw.assign(n_contours, false);
@@ -657,32 +657,32 @@ static inline coordf_t measure_perimeter_segment_on_vertical_line_length(
 // The first point (the point of iIntersection) will not be inserted,
 // the last point will be inserted.
 static inline void emit_perimeter_segment_on_vertical_line(
-	const ExPolygonWithOffset                     &poly_with_offset,
-	const std::vector<SegmentedIntersectionLine>  &segs,
-	size_t                                         iVerticalLine,
-	size_t                                         iInnerContour,
-	size_t                                         iIntersection,
-	size_t                                         iIntersection2,
-	Polyline                                      &out,
-	bool                                           forward)
+    const ExPolygonWithOffset                     &poly_with_offset,
+    const std::vector<SegmentedIntersectionLine>  &segs,
+    size_t                                         iVerticalLine,
+    size_t                                         iInnerContour,
+    size_t                                         iIntersection,
+    size_t                                         iIntersection2,
+    Polyline                                      &out,
+    bool                                           forward)
 {
-	const SegmentedIntersectionLine &il = segs[iVerticalLine];
-	const SegmentIntersection       &itsct = il.intersections[iIntersection];
-	const SegmentIntersection       &itsct2 = il.intersections[iIntersection2];
-	const Polygon                   &poly = poly_with_offset.contour(iInnerContour);
-	assert(itsct.is_inner());
-	assert(itsct2.is_inner());
-	assert(itsct.type != itsct2.type);
+    const SegmentedIntersectionLine &il = segs[iVerticalLine];
+    const SegmentIntersection       &itsct = il.intersections[iIntersection];
+    const SegmentIntersection       &itsct2 = il.intersections[iIntersection2];
+    const Polygon                   &poly = poly_with_offset.contour(iInnerContour);
+    assert(itsct.is_inner());
+    assert(itsct2.is_inner());
+    assert(itsct.type != itsct2.type);
     assert(itsct.iContour == iInnerContour);
-	assert(itsct.iContour == itsct2.iContour);
-	// Do not append the first point.
-	// out.points.push_back(Point(il.pos, itsct.pos));
-	if (forward)
-		polygon_segment_append(out.points, poly, itsct.iSegment, itsct2.iSegment);
-	else
-		polygon_segment_append_reversed(out.points, poly, itsct.iSegment, itsct2.iSegment);
-	// Append the last point.
-	out.points.push_back(Point(il.pos, itsct2.pos()));
+    assert(itsct.iContour == itsct2.iContour);
+    // Do not append the first point.
+    // out.points.push_back(Point(il.pos, itsct.pos));
+    if (forward)
+        polygon_segment_append(out.points, poly, itsct.iSegment, itsct2.iSegment);
+    else
+        polygon_segment_append_reversed(out.points, poly, itsct.iSegment, itsct2.iSegment);
+    // Append the last point.
+    out.points.push_back(Point(il.pos, itsct2.pos()));
 }
 
 //TBD: For precise infill, measure the area of a slab spanned by an infill line.
@@ -810,9 +810,9 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
     // Intersect a set of euqally spaced vertical lines wiht expolygon.
     // n_vlines = ceil(bbox_width / line_spacing)
     size_t  n_vlines = (bounding_box.max.x - bounding_box.min.x + line_spacing - 1) / line_spacing;
-	coord_t x0 = bounding_box.min.x;
-	if (params.full_infill())
-		x0 += (line_spacing + SCALED_EPSILON) / 2;
+    coord_t x0 = bounding_box.min.x;
+    if (params.full_infill())
+        x0 += (line_spacing + SCALED_EPSILON) / 2;
 
 #ifdef SLIC3R_DEBUG
     static int iRun = 0;
@@ -863,7 +863,7 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
             assert(ir >= 0 && ir < segs.size());
             for (int i = il; i <= ir; ++ i) {
                 coord_t this_x = segs[i].pos;
-				assert(this_x == i * line_spacing + x0);
+                assert(this_x == i * line_spacing + x0);
                 SegmentIntersection is;
                 is.iContour = iContour;
                 is.iSegment = iSegment;
@@ -1182,7 +1182,7 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
 
             // 3) Sort the intersection points, clear iPrev / iNext / iSegBelow / iSegAbove,
             // if it is preceded by any other intersection point along the contour.
-			unsigned int vert_seg_dir_valid_mask = 
+            unsigned int vert_seg_dir_valid_mask = 
                 (going_up ? 
                     (iSegAbove != -1 && seg.intersections[iAbove].type == SegmentIntersection::INNER_LOW) :
                     (iSegBelow != -1 && seg.intersections[iBelow].type == SegmentIntersection::INNER_HIGH)) ?
@@ -1271,23 +1271,23 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
             if (vert_seg_dir_valid_mask) {
                 bool valid = true;
                 // Verify, that there is no intersection with the inner contour up to the end of the contour segment.
-				// Verify, that the successive segment has not been consumed yet.
-				if (going_up) {
-					if (seg.intersections[iAbove].consumed_vertical_up) {
-						valid = false;
-					} else {
-						for (int i = (int)i_intersection + 1; i < iAbove && valid; ++i)
-							if (seg.intersections[i].is_inner()) 
-								valid = false;
-					}
+                // Verify, that the successive segment has not been consumed yet.
+                if (going_up) {
+                    if (seg.intersections[iAbove].consumed_vertical_up) {
+                        valid = false;
+                    } else {
+                        for (int i = (int)i_intersection + 1; i < iAbove && valid; ++i)
+                            if (seg.intersections[i].is_inner()) 
+                                valid = false;
+                    }
                 } else {
-					if (seg.intersections[iBelow-1].consumed_vertical_up) {
-						valid = false;
-					} else {
-						for (int i = iBelow + 1; i < (int)i_intersection && valid; ++i)
-							if (seg.intersections[i].is_inner()) 
-								valid = false;
-					}
+                    if (seg.intersections[iBelow-1].consumed_vertical_up) {
+                        valid = false;
+                    } else {
+                        for (int i = iBelow + 1; i < (int)i_intersection && valid; ++i)
+                            if (seg.intersections[i].is_inner()) 
+                                valid = false;
+                    }
                 }
                 if (valid) {
                     const Polygon &poly = poly_with_offset.contour(intrsctn->iContour);
@@ -1356,9 +1356,9 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
         assert(! polyline_current->has_duplicate_points());
         // Handle nearly zero length edges.
         if (polyline_current->points.size() <= 1 ||
-        	(polyline_current->points.size() == 2 &&
-        		std::abs(polyline_current->points.front().x - polyline_current->points.back().x) < SCALED_EPSILON &&
-				std::abs(polyline_current->points.front().y - polyline_current->points.back().y) < SCALED_EPSILON))
+            (polyline_current->points.size() == 2 &&
+                std::abs(polyline_current->points.front().x - polyline_current->points.back().x) < SCALED_EPSILON &&
+                std::abs(polyline_current->points.front().y - polyline_current->points.back().y) < SCALED_EPSILON))
             polylines_out.pop_back();
         intrsctn = NULL;
         i_intersection = -1;
@@ -1471,8 +1471,8 @@ Polylines FillCubic::fill_surface(const Surface *surface, const FillParams &para
 
 Polylines FillSmooth::fill_surface(const Surface *surface, const FillParams &params)
 {
-	//ERROR: you shouldn't call that. Default to the rectilinear one.
-	printf("FillSmooth::fill_surface() : you call the wrong method (fill_surface instead of fill_surface_extrusion).\n");
+    //ERROR: you shouldn't call that. Default to the rectilinear one.
+    printf("FillSmooth::fill_surface() : you call the wrong method (fill_surface instead of fill_surface_extrusion).\n");
     Polylines polylines_out;
     if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out)) {
         printf("FillRectilinear2::fill_surface() failed to fill a region.\n");
@@ -1483,80 +1483,80 @@ Polylines FillSmooth::fill_surface(const Surface *surface, const FillParams &par
 
 void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out )
 {
-	//second pass with half layer width
+    //second pass with half layer width
     FillParams params2 = params;
     params2.density *= 2.0f;
     Polylines polylines_out;
     Polylines polylines_outNoExtrud;
-	
-	//choose between v1 (no extrusion on second pass) and v2 (small extrusion on second pass)
-	if(surface->area() < (scale_(this->spacing)*scale_(this->spacing)) * 200){
-		//v1 (only if < 200 nozzle� (for a 0.4 nozzle, it's 32 mm� ~ 0.32 cm� ~ a 5mmx5mm cube on a notebook)
-		//TODO: also use the v1 if the surface is too narrow (no 5x5mm cube can fit inside)
-		
-		// a complete perimeter overlap (no extrusion anyway)
-		Surface surfaceIncr(*surface);
-		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_(this->spacing)); 
-		surfaceIncr.expolygon.contour = paths[0];
-		
-		if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
-			! fill_surface_by_lines(&surfaceIncr, params2, float(M_PI/2), 0.f, polylines_outNoExtrud)) {
-			printf("FillSmooth::fill_surface() failed to fill a region.\n");
-		} 
-		
-		if (polylines_out.empty())
-			return;
-		
-		out.entities.push_back(create_extrusions(1.f, 0.f, polylines_out, polylines_outNoExtrud, flow));
-	}else{
-		//v2
-		
-		 //a small overlap
-		Surface surfaceIncr(*surface);
-		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_((float)this->spacing * 0.25f));
-		surfaceIncr.expolygon.contour = paths[0];
-		
-		if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
-			! fill_surface_by_lines(&surfaceIncr, params2, float(M_PI/2), 0.f, polylines_outNoExtrud)) {
-			printf("FillSmooth::fill_surface() failed to fill a region.\n");
-		} 
-		
-		if (polylines_out.empty())
-			return;
-		
-		out.entities.push_back(create_extrusions(0.95f, 0.15f, polylines_out, polylines_outNoExtrud, flow));
-	}
-	
+    
+    //choose between v1 (no extrusion on second pass) and v2 (small extrusion on second pass)
+    if(surface->area() < (scale_(this->spacing)*scale_(this->spacing)) * 200){
+        //v1 (only if < 200 nozzle� (for a 0.4 nozzle, it's 32 mm� ~ 0.32 cm� ~ a 5mmx5mm cube on a notebook)
+        //TODO: also use the v1 if the surface is too narrow (no 5x5mm cube can fit inside)
+        
+        // a (more than) complete perimeter overlap (no extrusion anyway)
+        Surface surfaceIncr(*surface);
+        Polygons paths = offset(surfaceIncr.expolygon.contour, scale_(this->spacing)); 
+        surfaceIncr.expolygon.contour = paths[0];
+        
+        if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
+            ! fill_surface_by_lines(&surfaceIncr, params2, float(M_PI/2), 0.f, polylines_outNoExtrud)) {
+            printf("FillSmooth::fill_surface() failed to fill a region.\n");
+        } 
+        
+        if (polylines_out.empty())
+            return;
+        
+        out.entities.push_back(create_extrusions(1.f, 0.f, polylines_out, polylines_outNoExtrud, flow));
+    }else{
+        //v2
+        
+         //a small overlap
+        Surface surfaceIncr(*surface);
+        Polygons paths = offset(surfaceIncr.expolygon.contour, scale_((float)this->spacing * 0.25f));
+        surfaceIncr.expolygon.contour = paths[0];
+        
+        if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
+            ! fill_surface_by_lines(&surfaceIncr, params2, float(M_PI/2), 0.f, polylines_outNoExtrud)) {
+            printf("FillSmooth::fill_surface() failed to fill a region.\n");
+        } 
+        
+        if (polylines_out.empty())
+            return;
+        
+        out.entities.push_back(create_extrusions(0.95f, 0.15f, polylines_out, polylines_outNoExtrud, flow));
+    }
+    
 }
 
 ExtrusionEntityCollection* FillSmooth::create_extrusions(const float flowThickP, const float flowThinP, Polylines &polylines_thick, Polylines &polylines_thin, const Flow &flow){
-	
-	ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
-	//you don't want to sort the extrusions: big infill first, quick weak second
-	eecroot->no_sort = true;
-	
-	// Save into layer.
-	ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
-	eecroot->entities.push_back(eec);
-	eec->no_sort = true;
-	// print thick
-	extrusion_entities_append_paths(
-		eec->entities, STDMOVE(polylines_thick),
-		flow.bridge ? erBridgeInfill : erTopSolidInfill,
-		flow.mm3_per_mm()*flowThickP, (float)flow.width*1.f, (float)flow.height);
-		//note: the flow.width*0.9 is here only for the gui (visual) , the flow.mm3_per_mm() is the real one
-		
-	// Save into layer smoothing path.
-	eec = new ExtrusionEntityCollection();
-	eecroot->entities.push_back(eec);
-	eec->no_sort = true;
-	// print thin
-	extrusion_entities_append_paths(
-		eec->entities, STDMOVE(polylines_thin),
-		erInternalInfill, //speedy (it's generally the most speedy)
-		flow.mm3_per_mm()*flowThinP, (float)flow.width*0.15f, (float)flow.height);
-	
-	return eecroot;
+    
+    ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
+    //you don't want to sort the extrusions: big infill first, quick weak second
+    eecroot->no_sort = true;
+    
+    // Save into layer.
+    ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
+    eecroot->entities.push_back(eec);
+    eec->no_sort = true;
+    // print thick
+    extrusion_entities_append_paths(
+        eec->entities, STDMOVE(polylines_thick),
+        flow.bridge ? erBridgeInfill : erTopSolidInfill,
+        flow.mm3_per_mm()*flowThickP, (float)flow.width*1.f, (float)flow.height);
+        //note: the flow.width*0.9 is here only for the gui (visual) , the flow.mm3_per_mm() is the real one
+        
+    // Save into layer smoothing path.
+    eec = new ExtrusionEntityCollection();
+    eecroot->entities.push_back(eec);
+    eec->no_sort = true;
+    // print thin
+    extrusion_entities_append_paths(
+        eec->entities, STDMOVE(polylines_thin),
+        erInternalInfill, //speedy (it's generally the most speedy)
+        flow.mm3_per_mm()*flowThinP, (float)flow.width*0.15f, (float)flow.height);
+    
+    return eecroot;
 }
 
 } // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -1500,12 +1500,16 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 	
 	ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
 	out.entities.push_back(eecroot);
+	out.name = "root";
+	eecroot->name = "nosortnode";
 	eecroot->no_sort = true;
 	
 	// float stdflowWidth = tempFlow.width;
 	// Save into layer.
 	ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
 	eecroot->entities.push_back(eec);
+	eec->no_sort = true;
+	eec->name = "full";
 	// tempFlow.width = stdflowWidth * 0.9f; // print almost 100% (90%)
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_out),
@@ -1514,11 +1518,13 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 			(surface->is_solid() ?
 				((surface->surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
 				erInternalInfill),
-		flow.mm3_per_mm()*0.95, flow.width*0.95, flow.height);
+		flow.mm3_per_mm()*0.9, flow.width*0.9, flow.height);
 		
 	// Save into layer smoothing path.
 	eec = new ExtrusionEntityCollection();
 	eecroot->entities.push_back(eec);
+	eec->no_sort = true;
+	eec->name = "sparse";
 	// tempFlow.width = stdflowWidth * 0.05f; //print the last 10% (with 2 times more lines) -> gapfill
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_outNoExtrud),

--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -1500,8 +1500,6 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 	
 	ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
 	out.entities.push_back(eecroot);
-	out.name = "root";
-	eecroot->name = "nosortnode";
 	eecroot->no_sort = true;
 	
 	// float stdflowWidth = tempFlow.width;
@@ -1509,8 +1507,7 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 	ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
 	eecroot->entities.push_back(eec);
 	eec->no_sort = true;
-	eec->name = "full";
-	// tempFlow.width = stdflowWidth * 0.9f; // print almost 100% (90%)
+	// print at almost 100% (90%) flow
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_out),
 		flow.bridge ?
@@ -1524,13 +1521,11 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 	eec = new ExtrusionEntityCollection();
 	eecroot->entities.push_back(eec);
 	eec->no_sort = true;
-	eec->name = "sparse";
-	// tempFlow.width = stdflowWidth * 0.05f; //print the last 10% (with 2 times more lines) -> gapfill
+	//print the last 10% with 2*15% -> gapfill (if less => gaps)
 	extrusion_entities_append_paths(
 		eec->entities, STDMOVE(polylines_outNoExtrud),
-		erInternalInfill, //speedy (or use erInternalInfill, erNone)
+		erInternalInfill, //speedy (it's generally the most speedy)
 		flow.mm3_per_mm()*0.15, flow.width*0.15, flow.height);
-	// std::cout<<"std : flow"<<(flow.mm3_per_mm()*0.2)<<", width"<<(flow.width*0.2)<<", height"<<(flow.height)<<"\n";
 }
 
 } // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -1471,16 +1471,16 @@ Polylines FillCubic::fill_surface(const Surface *surface, const FillParams &para
 
 Polylines FillSmooth::fill_surface(const Surface *surface, const FillParams &params)
 {
-	//second pass with half layer width
-    FillParams params2 = params;
-    params2.density *= 2.0f;
+	//ERROR: you shouldn't call that. Default to the rectilinear one.
+	printf("FillSmooth::fill_surface() : you call the wrong method (fill_surface instead of fill_surface_extrusion).\n");
     Polylines polylines_out;
-    if (! fill_surface_by_lines(surface, params, 0.f, 0., polylines_out) ||
-        ! fill_surface_by_lines(surface, params2, float(M_PI/2), 0., polylines_out)) {
-        printf("FillCubic::fill_surface() failed to fill a region.\n");
-    } 
-    return polylines_out; 
+    if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out)) {
+        printf("FillRectilinear2::fill_surface() failed to fill a region.\n");
+    }
+    return polylines_out;
 }
+
+
 void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out )
 {
 	//second pass with half layer width
@@ -1490,10 +1490,13 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
     Polylines polylines_outNoExtrud;
 	
 	//choose between v1 (no extrusion on second pass) and v2 (small extrusion on second pass)
-	if(surface->area() < (scale_(this->spacing)*scale_(this->spacing)) * 100){
-		//v1 (only if < 100 nozzle² (for a 0.4 nozzle, it's 16 mm² ~ 0.16 cm² ~ half of a 5mmx5mm cube on a notebook)
+	if(surface->area() < (scale_(this->spacing)*scale_(this->spacing)) * 200){
+		//v1 (only if < 200 nozzle² (for a 0.4 nozzle, it's 32 mm² ~ 0.32 cm² ~ a 5mmx5mm cube on a notebook)
+		//TODO: also use the v1 if the surface is too narrow (no 5x5mm cube can fit inside)
+		
+		// a complete perimeter overlap (no extrusion anyway)
 		Surface surfaceIncr(*surface);
-		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_(this->spacing));
+		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_(this->spacing)); 
 		surfaceIncr.expolygon.contour = paths[0];
 		
 		if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
@@ -1504,40 +1507,13 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 		if (polylines_out.empty())
 			return;
 		
-		// Flow tempFlow = flow;
-		
-		ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
-		out.entities.push_back(eecroot);
-		eecroot->no_sort = true;
-		
-		// float stdflowWidth = tempFlow.width;
-		// Save into layer.
-		ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
-		eecroot->entities.push_back(eec);
-		eec->no_sort = true;
-		// print at almost 100% (90%) flow
-		extrusion_entities_append_paths(
-			eec->entities, STDMOVE(polylines_out),
-			flow.bridge ?
-				erBridgeInfill :
-				(surface->is_solid() ?
-					((surface->surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
-					erInternalInfill),
-			flow.mm3_per_mm()*1, flow.width*1, flow.height);
-			
-		// Save into layer smoothing path.
-		eec = new ExtrusionEntityCollection();
-		eecroot->entities.push_back(eec);
-		eec->no_sort = true;
-		//print the last 10% with 2*15% -> gapfill (if less => gaps)
-		extrusion_entities_append_paths(
-			eec->entities, STDMOVE(polylines_outNoExtrud),
-			erInternalInfill, //speedy (it's generally the most speedy)
-			0.f, flow.width*0.05, flow.height);
+		out.entities.push_back(create_extrusions(1.f, 0.f, polylines_out, polylines_outNoExtrud, flow));
 	}else{
 		//v2
+		
+		 //a small overlap
 		Surface surfaceIncr(*surface);
-		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_(this->spacing * 0.3f));
+		Polygons paths = offset(surfaceIncr.expolygon.contour, scale_((float)this->spacing * 0.25f));
 		surfaceIncr.expolygon.contour = paths[0];
 		
 		if (! fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out) ||
@@ -1548,38 +1524,39 @@ void FillSmooth::fill_surface_extrusion(const Surface *surface, const FillParams
 		if (polylines_out.empty())
 			return;
 		
-		// Flow tempFlow = flow;
-		
-		ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
-		out.entities.push_back(eecroot);
-		eecroot->no_sort = true;
-		
-		// float stdflowWidth = tempFlow.width;
-		// Save into layer.
-		ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
-		eecroot->entities.push_back(eec);
-		eec->no_sort = true;
-		// print at almost 100% (90%) flow
-		extrusion_entities_append_paths(
-			eec->entities, STDMOVE(polylines_out),
-			flow.bridge ?
-				erBridgeInfill :
-				(surface->is_solid() ?
-					((surface->surface_type == stTop) ? erTopSolidInfill : erSolidInfill) :
-					erInternalInfill),
-			flow.mm3_per_mm()*0.9, flow.width*0.9, flow.height);
-			
-		// Save into layer smoothing path.
-		eec = new ExtrusionEntityCollection();
-		eecroot->entities.push_back(eec);
-		eec->no_sort = true;
-		//print the last 10% with 2*15% -> gapfill (if less => gaps)
-		extrusion_entities_append_paths(
-			eec->entities, STDMOVE(polylines_outNoExtrud),
-			erInternalInfill, //speedy (it's generally the most speedy)
-			flow.mm3_per_mm()*0.15, flow.width*0.15, flow.height);
+		out.entities.push_back(create_extrusions(0.95f, 0.15f, polylines_out, polylines_outNoExtrud, flow));
 	}
 	
+}
+
+ExtrusionEntityCollection* FillSmooth::create_extrusions(const float flowThickP, const float flowThinP, Polylines &polylines_thick, Polylines &polylines_thin, const Flow &flow){
+	
+	ExtrusionEntityCollection *eecroot = new ExtrusionEntityCollection();
+	//you don't want to sort the extrusions: big infill first, quick weak second
+	eecroot->no_sort = true;
+	
+	// Save into layer.
+	ExtrusionEntityCollection *eec = new ExtrusionEntityCollection();
+	eecroot->entities.push_back(eec);
+	eec->no_sort = true;
+	// print thick
+	extrusion_entities_append_paths(
+		eec->entities, STDMOVE(polylines_thick),
+		flow.bridge ? erBridgeInfill : erTopSolidInfill,
+		flow.mm3_per_mm()*flowThickP, (float)flow.width*1.f, (float)flow.height);
+		//note: the flow.width*0.9 is here only for the gui (visual) , the flow.mm3_per_mm() is the real one
+		
+	// Save into layer smoothing path.
+	eec = new ExtrusionEntityCollection();
+	eecroot->entities.push_back(eec);
+	eec->no_sort = true;
+	// print thin
+	extrusion_entities_append_paths(
+		eec->entities, STDMOVE(polylines_thin),
+		erInternalInfill, //speedy (it's generally the most speedy)
+		flow.mm3_per_mm()*flowThinP, (float)flow.width*0.15f, (float)flow.height);
+	
+	return eecroot;
 }
 
 } // namespace Slic3r

--- a/xs/src/libslic3r/Fill/FillRectilinear2.hpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.hpp
@@ -68,6 +68,17 @@ protected:
     virtual float _layer_angle(size_t idx) const { return 0.f; }
 };
 
+class FillSmooth : public FillRectilinear2
+{
+public:
+    virtual Fill* clone() const { return new FillSmooth(*this); };
+    virtual ~FillSmooth() {}
+    virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
+    virtual bool can_create_extrusion_entity_collection() const { return true; }
+    virtual void fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out );
+
+};
+
 
 }; // namespace Slic3r
 

--- a/xs/src/libslic3r/Fill/FillRectilinear2.hpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.hpp
@@ -76,6 +76,7 @@ public:
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
     virtual bool can_create_extrusion_entity_collection() const { return true; }
     virtual void fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out );
+    virtual ExtrusionEntityCollection* create_extrusions(const float percent_flow_thick, const float percent_flow_thin, Polylines &polylines_thick, Polylines &polylines_thin, const Flow &flow);
 
 };
 

--- a/xs/src/libslic3r/Fill/FillRectilinear2.hpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.hpp
@@ -74,7 +74,6 @@ public:
     virtual Fill* clone() const { return new FillSmooth(*this); };
     virtual ~FillSmooth() {}
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
-    virtual bool can_create_extrusion_entity_collection() const { return true; }
     virtual void fill_surface_extrusion(const Surface *surface, const FillParams &params, const Flow &flow, ExtrusionEntityCollection &out );
     virtual ExtrusionEntityCollection* create_extrusions(const float percent_flow_thick, const float percent_flow_thin, Polylines &polylines_thick, Polylines &polylines_thin, const Flow &flow);
 

--- a/xs/src/libslic3r/Fill/FillRectilinear2.hpp
+++ b/xs/src/libslic3r/Fill/FillRectilinear2.hpp
@@ -17,7 +17,7 @@ public:
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
 
 protected:
-	bool fill_surface_by_lines(const Surface *surface, const FillParams &params, float angleBase, float pattern_shift, Polylines &polylines_out);
+    bool fill_surface_by_lines(const Surface *surface, const FillParams &params, float angleBase, float pattern_shift, Polylines &polylines_out);
 };
 
 class FillGrid2 : public FillRectilinear2
@@ -28,7 +28,7 @@ public:
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
 
 protected:
-	// The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
+    // The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
     virtual float _layer_angle(size_t idx) const { return 0.f; }
 };
 
@@ -40,7 +40,7 @@ public:
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
 
 protected:
-	// The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
+    // The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
     virtual float _layer_angle(size_t idx) const { return 0.f; }
 };
 
@@ -64,7 +64,7 @@ public:
     virtual Polylines fill_surface(const Surface *surface, const FillParams &params);
 
 protected:
-	// The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
+    // The grid fill will keep the angle constant between the layers, see the implementation of Slic3r::Fill.
     virtual float _layer_angle(size_t idx) const { return 0.f; }
 };
 

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -1223,13 +1223,6 @@ void GCode::process_layer(
                     if (fill->entities.empty())
                         // This shouldn't happen but first_point() would fail.
                         continue;
-					std::cout<<"process_layer infill "<<fill->name<<"\n";
-					if(fill->name == "nosortnode"){
-						std::cout<<"test order: "<<fill->entities.size()<<"\n";
-//						std::cout<<"0:"<<((ExtrusionEntityCollection*)(&(fill->entities[0])))->name<<"\n";
-//						std::cout<<"1:"<<((ExtrusionEntityCollection*)(&(fill->entities[1])))->name<<"\n";
-						
-					}
                     // init by_extruder item only if we actually use the extruder
                     int extruder_id = std::max<int>(0, (is_solid_infill(fill->entities.front()->role()) ? region.config.solid_infill_extruder : region.config.infill_extruder) - 1);
                     // Init by_extruder item only if we actually use the extruder.
@@ -1245,8 +1238,6 @@ void GCode::process_layer(
                             point_inside_surface(i, fill->first_point())) {
                             if (islands[i].by_region.empty())
                                 islands[i].by_region.assign(print.regions.size(), ObjectByExtruder::Island::Region());
-							std::cout<<"process_layer infill (child) "<<fill->name<<"\n";
-							if(fill->name == "nosortnode") islands[i].by_region[region_id].infills.name = "take_"+fill->name;
 							//don't do fill->entities because it will discard no_sort
 							//fill->flattenIfSortable().entities keep no_sort attribute. !! it create a new ExtrusionEntityCollection tree, 
 							//  be careful to delete properly the new(flattenIfSortable()) / old(fill)one (fill) !! (not 100% sure yet) TODO: review
@@ -1969,9 +1960,7 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
     std::string gcode;
     for (const ObjectByExtruder::Island::Region &region : by_region) {
         m_config.apply(print.regions[&region - &by_region.front()]->config);
-				std::cout<<"extrude region.infills:"<<region.infills.name<<"\n";
 		ExtrusionEntityCollection chained = region.infills.chained_path_from(m_last_pos, false);
-				std::cout<<"extrude ExtrusionEntityCollection:"<<chained.name<<"\n";
         gcode += extrude_infill(print, chained);
     }
     return gcode;
@@ -1980,7 +1969,6 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
 std::string GCode::extrude_infill(const Print &print, const ExtrusionEntityCollection &collection)
 {
     std::string gcode;
-	std::cout<<"extrude collection:"<<collection.name<<"\n";
 
 	ExtrusionEntityCollection chained;
 	if(collection.no_sort) chained = collection;
@@ -1988,7 +1976,7 @@ std::string GCode::extrude_infill(const Print &print, const ExtrusionEntityColle
 	for (ExtrusionEntity *fill : chained.entities) {
 		auto *eec = dynamic_cast<ExtrusionEntityCollection*>(fill);
 		if (eec) {
-			extrude_infill(print, *eec);
+			gcode += extrude_infill(print, *eec);
 		} else
 			gcode += this->extrude_entity(*fill, "infill");
 	}

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -182,7 +182,7 @@ std::string WipeTowerIntegration::append_tcr(GCode &gcodegen, const WipeTower::T
     // Inform the G-code writer about the changes done behind its back.
     gcode += tcr.gcode;
     // Let the m_writer know the current extruder_id, but ignore the generated G-code.
-	if (new_extruder_id >= 0 && gcodegen.writer().need_toolchange(new_extruder_id))
+    if (new_extruder_id >= 0 && gcodegen.writer().need_toolchange(new_extruder_id))
         gcodegen.writer().toolchange(new_extruder_id);
     // Always append the filament start G-code even if the extruder did not switch,
     // because the wipe tower resets the linear advance and we want it to be re-enabled.
@@ -246,12 +246,12 @@ std::string WipeTowerIntegration::prime(GCode &gcodegen)
 std::string WipeTowerIntegration::tool_change(GCode &gcodegen, int extruder_id, bool finish_layer)
 {
     std::string gcode;
-	assert(m_layer_idx >= 0 && m_layer_idx <= m_tool_changes.size());
+    assert(m_layer_idx >= 0 && m_layer_idx <= m_tool_changes.size());
     if (! m_brim_done || gcodegen.writer().need_toolchange(extruder_id) || finish_layer) {
-		if (m_layer_idx < m_tool_changes.size()) {
-			assert(m_tool_change_idx < m_tool_changes[m_layer_idx].size());
-			gcode += append_tcr(gcodegen, m_tool_changes[m_layer_idx][m_tool_change_idx++], extruder_id);
-		}
+        if (m_layer_idx < m_tool_changes.size()) {
+            assert(m_tool_change_idx < m_tool_changes[m_layer_idx].size());
+            gcode += append_tcr(gcodegen, m_tool_changes[m_layer_idx][m_tool_change_idx++], extruder_id);
+        }
         m_brim_done = true;
     }
     return gcode;
@@ -529,19 +529,19 @@ void GCode::_do_export(Print &print, FILE *file)
     size_t       initial_print_object_id = 0;
     bool         has_wipe_tower      = false;
     if (print.config.complete_objects.value) {
-		// Find the 1st printing object, find its tool ordering and the initial extruder ID.
-		for (; initial_print_object_id < print.objects.size(); ++initial_print_object_id) {
-			tool_ordering = ToolOrdering(*print.objects[initial_print_object_id], initial_extruder_id);
-			if ((initial_extruder_id = tool_ordering.first_extruder()) != (unsigned int)-1)
-				break;
-		}
-	} else {
-		// Find tool ordering for all the objects at once, and the initial extruder ID.
+        // Find the 1st printing object, find its tool ordering and the initial extruder ID.
+        for (; initial_print_object_id < print.objects.size(); ++initial_print_object_id) {
+            tool_ordering = ToolOrdering(*print.objects[initial_print_object_id], initial_extruder_id);
+            if ((initial_extruder_id = tool_ordering.first_extruder()) != (unsigned int)-1)
+                break;
+        }
+    } else {
+        // Find tool ordering for all the objects at once, and the initial extruder ID.
         // If the tool ordering has been pre-calculated by Print class for wipe tower already, reuse it.
-		tool_ordering = print.m_tool_ordering.empty() ?
+        tool_ordering = print.m_tool_ordering.empty() ?
             ToolOrdering(print, initial_extruder_id) :
             print.m_tool_ordering;
-		initial_extruder_id = tool_ordering.first_extruder();
+        initial_extruder_id = tool_ordering.first_extruder();
         has_wipe_tower = print.has_wipe_tower() && tool_ordering.has_wipe_tower();
     }
     if (initial_extruder_id == (unsigned int)-1) {
@@ -1032,7 +1032,7 @@ void GCode::process_layer(
             + "\n";
     }
     gcode += this->change_layer(print_z);  // this will increase m_layer_index
-	m_layer = &layer;
+    m_layer = &layer;
     if (! print.config.layer_gcode.value.empty()) {
         DynamicConfig config;
         config.set_key_value("layer_num", new ConfigOptionInt(m_layer_index));
@@ -1061,18 +1061,18 @@ void GCode::process_layer(
     // Extrude skirt at the print_z of the raft layers and normal object layers
     // not at the print_z of the interlaced support material layers.
     bool extrude_skirt = 
-		! print.skirt.entities.empty() &&
+        ! print.skirt.entities.empty() &&
         // Not enough skirt layers printed yet.
         (m_skirt_done.size() < print.config.skirt_height.value || print.has_infinite_skirt()) &&
         // This print_z has not been extruded yet
-		(m_skirt_done.empty() ? 0. : m_skirt_done.back()) < print_z - EPSILON &&
+        (m_skirt_done.empty() ? 0. : m_skirt_done.back()) < print_z - EPSILON &&
         // and this layer is the 1st layer, or it is an object layer, or it is a raft layer.
         (first_layer || object_layer != nullptr || support_layer->id() < m_config.raft_layers.value);
     std::map<unsigned int, std::pair<size_t, size_t>> skirt_loops_per_extruder;
     coordf_t                                          skirt_height = 0.;
     if (extrude_skirt) {
         // Fill in skirt_loops_per_extruder.
-		skirt_height = print_z - (m_skirt_done.empty() ? 0. : m_skirt_done.back());
+        skirt_height = print_z - (m_skirt_done.empty() ? 0. : m_skirt_done.back());
         m_skirt_done.push_back(print_z);
         if (first_layer) {
             // Prime the extruders over the skirt lines.
@@ -1086,8 +1086,8 @@ void GCode::process_layer(
                     break;
                 }
             size_t n_loops = print.skirt.entities.size();
-			if (n_loops <= extruder_ids.size()) {
-				for (size_t i = 0; i < n_loops; ++i)
+            if (n_loops <= extruder_ids.size()) {
+                for (size_t i = 0; i < n_loops; ++i)
                     skirt_loops_per_extruder[extruder_ids[i]] = std::pair<size_t, size_t>(i, i + 1);
             } else {
                 // Assign skirt loops to the extruders.
@@ -1238,9 +1238,9 @@ void GCode::process_layer(
                             point_inside_surface(i, fill->first_point())) {
                             if (islands[i].by_region.empty())
                                 islands[i].by_region.assign(print.regions.size(), ObjectByExtruder::Island::Region());
-							//don't do fill->entities because it will discard no_sort
-							//fill->flattenIfSortable().entities keep no_sort attribute. !! it create a new ExtrusionEntityCollection tree, 
-							//  be careful to delete properly the new(flattenIfSortable()) / old(fill)one (fill) !! (not 100% sure yet) TODO: review
+                            //don't do fill->entities because it will discard no_sort
+                            //fill->flattenIfSortable().entities keep no_sort attribute. !! it create a new ExtrusionEntityCollection tree, 
+                            //  be careful to delete properly the new(flattenIfSortable()) / old(fill)one (fill) !! (not 100% sure yet) TODO: review
                             islands[i].by_region[region_id].infills.append(fill->flattenIfSortable().entities); 
                             break;
                         }
@@ -1301,9 +1301,9 @@ void GCode::process_layer(
         for (const ObjectByExtruder &object_by_extruder : objects_by_extruder_it->second) {
             const size_t       layer_id     = &object_by_extruder - objects_by_extruder_it->second.data();
             const PrintObject *print_object = layers[layer_id].object();
-			if (print_object == nullptr)
-				// This layer is empty for this particular object, it has neither object extrusions nor support extrusions at this print_z.
-				continue;
+            if (print_object == nullptr)
+                // This layer is empty for this particular object, it has neither object extrusions nor support extrusions at this print_z.
+                continue;
             if (m_enable_analyzer_markers) {
                 // Store the binary pointer to the layer object directly into the G-code to be accessed by the GCodeAnalyzer.
                 char buf[64];
@@ -1471,16 +1471,16 @@ static inline const char* ExtrusionLoopRole2String(const ExtrusionLoopRole role)
 static inline float bspline_kernel(float x)
 {
     x = std::abs(x);
-	if (x < 1.f) {
-		return 1.f - (3.f / 2.f) * x * x + (3.f / 4.f) * x * x * x;
-	}
-	else if (x < 2.f) {
-		x -= 1.f;
-		float x2 = x * x;
-		float x3 = x2 * x;
-		return (1.f / 4.f) - (3.f / 4.f) * x + (3.f / 4.f) * x2 - (1.f / 4.f) * x3;
-	}
-	else
+    if (x < 1.f) {
+        return 1.f - (3.f / 2.f) * x * x + (3.f / 4.f) * x * x * x;
+    }
+    else if (x < 2.f) {
+        x -= 1.f;
+        float x2 = x * x;
+        float x3 = x2 * x;
+        return (1.f / 4.f) - (3.f / 4.f) * x + (3.f / 4.f) * x2 - (1.f / 4.f) * x3;
+    }
+    else
         return 0;
 }
 
@@ -1553,13 +1553,13 @@ static Points::iterator project_point_to_polygon_and_insert(Polygon &polygon, co
                 pt_min = p1;
                 double linv = double(d_seg) / double(l2_seg);
                 pt_min.x = pt.x - coord_t(floor(double(v_seg.y) * linv + 0.5));
-				pt_min.y = pt.y + coord_t(floor(double(v_seg.x) * linv + 0.5));
-				assert(Line(p1, p2).distance_to(pt_min) < scale_(1e-5));
+                pt_min.y = pt.y + coord_t(floor(double(v_seg.x) * linv + 0.5));
+                assert(Line(p1, p2).distance_to(pt_min) < scale_(1e-5));
             }
         }
     }
 
-	assert(i_min != size_t(-1));
+    assert(i_min != size_t(-1));
     if (pt_min.distance_to(polygon.points[i_min]) > eps) {
         // Insert a new point on the segment i_min, i_min+1.
         return polygon.points.insert(polygon.points.begin() + (i_min + 1), pt_min);
@@ -1623,9 +1623,9 @@ std::vector<float> polygon_angles_at_vertices(const Polygon &polygon, const std:
         const Point &p2 = polygon.points[idx_next];
         const Point  v1 = p0.vector_to(p1);
         const Point  v2 = p1.vector_to(p2);
-		int64_t dot   = int64_t(v1.x)*int64_t(v2.x) + int64_t(v1.y)*int64_t(v2.y);
-		int64_t cross = int64_t(v1.x)*int64_t(v2.y) - int64_t(v1.y)*int64_t(v2.x);
-		float angle = float(atan2(double(cross), double(dot)));
+        int64_t dot   = int64_t(v1.x)*int64_t(v2.x) + int64_t(v1.y)*int64_t(v2.y);
+        int64_t cross = int64_t(v1.x)*int64_t(v2.y) - int64_t(v1.y)*int64_t(v2.x);
+        float angle = float(atan2(double(cross), double(dot)));
         angles[idx_curr] = angle;
     }
 
@@ -1960,26 +1960,28 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
     std::string gcode;
     for (const ObjectByExtruder::Island::Region &region : by_region) {
         m_config.apply(print.regions[&region - &by_region.front()]->config);
-		ExtrusionEntityCollection chained = region.infills.chained_path_from(m_last_pos, false);
+        ExtrusionEntityCollection chained = region.infills.chained_path_from(m_last_pos, false);
         gcode += extrude_infill(print, chained);
     }
     return gcode;
 }
 
+//recursive algorithm to explore the collection tree
 std::string GCode::extrude_infill(const Print &print, const ExtrusionEntityCollection &collection)
 {
     std::string gcode;
 
-	ExtrusionEntityCollection chained;
-	if(collection.no_sort) chained = collection;
-	else chained = collection.chained_path_from(m_last_pos, false);
-	for (ExtrusionEntity *fill : chained.entities) {
-		auto *eec = dynamic_cast<ExtrusionEntityCollection*>(fill);
-		if (eec) {
-			gcode += extrude_infill(print, *eec);
-		} else
-			gcode += this->extrude_entity(*fill, "infill");
-	}
+    ExtrusionEntityCollection chained;
+    if(collection.no_sort) chained = collection;
+    else chained = collection.chained_path_from(m_last_pos, false);
+    for (ExtrusionEntity *fill : chained.entities) {
+        auto *eec = dynamic_cast<ExtrusionEntityCollection*>(fill);
+        if (eec) {
+            gcode += extrude_infill(print, *eec);
+        } else {
+            gcode += this->extrude_entity(*fill, "infill");
+        }
+    }
     return gcode;
 }
 
@@ -2213,7 +2215,7 @@ std::string GCode::travel_to(const Point &point, ExtrusionRole role, std::string
     // use G1 because we rely on paths being straight (G0 may make round paths)
     Lines lines = travel.lines();
     for (Lines::const_iterator line = lines.begin(); line != lines.end(); ++line)
-	    gcode += m_writer.travel_to_xy(this->point_to_gcode(line->b), comment);
+        gcode += m_writer.travel_to_xy(this->point_to_gcode(line->b), comment);
     
     return gcode;
 }

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -1223,6 +1223,13 @@ void GCode::process_layer(
                     if (fill->entities.empty())
                         // This shouldn't happen but first_point() would fail.
                         continue;
+					std::cout<<"process_layer infill "<<fill->name<<"\n";
+					if(fill->name == "nosortnode"){
+						std::cout<<"test order: "<<fill->entities.size()<<"\n";
+//						std::cout<<"0:"<<((ExtrusionEntityCollection*)(&(fill->entities[0])))->name<<"\n";
+//						std::cout<<"1:"<<((ExtrusionEntityCollection*)(&(fill->entities[1])))->name<<"\n";
+						
+					}
                     // init by_extruder item only if we actually use the extruder
                     int extruder_id = std::max<int>(0, (is_solid_infill(fill->entities.front()->role()) ? region.config.solid_infill_extruder : region.config.infill_extruder) - 1);
                     // Init by_extruder item only if we actually use the extruder.
@@ -1238,7 +1245,12 @@ void GCode::process_layer(
                             point_inside_surface(i, fill->first_point())) {
                             if (islands[i].by_region.empty())
                                 islands[i].by_region.assign(print.regions.size(), ObjectByExtruder::Island::Region());
-                            islands[i].by_region[region_id].infills.append(fill->entities);
+							std::cout<<"process_layer infill (child) "<<fill->name<<"\n";
+							if(fill->name == "nosortnode") islands[i].by_region[region_id].infills.name = "take_"+fill->name;
+							//don't do fill->entities because it will discard no_sort
+							//fill->flattenIfSortable().entities keep no_sort attribute. !! it create a new ExtrusionEntityCollection tree, 
+							//  be careful to delete properly the new(flattenIfSortable()) / old(fill)one (fill) !! (not 100% sure yet) TODO: review
+                            islands[i].by_region[region_id].infills.append(fill->flattenIfSortable().entities); 
                             break;
                         }
                 }
@@ -1957,17 +1969,29 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
     std::string gcode;
     for (const ObjectByExtruder::Island::Region &region : by_region) {
         m_config.apply(print.regions[&region - &by_region.front()]->config);
+				std::cout<<"extrude region.infills:"<<region.infills.name<<"\n";
 		ExtrusionEntityCollection chained = region.infills.chained_path_from(m_last_pos, false);
-        for (ExtrusionEntity *fill : chained.entities) {
-            auto *eec = dynamic_cast<ExtrusionEntityCollection*>(fill);
-            if (eec) {
-				ExtrusionEntityCollection chained2 = eec->chained_path_from(m_last_pos, false);
-				for (ExtrusionEntity *ee : chained2.entities)
-                    gcode += this->extrude_entity(*ee, "infill");
-            } else
-                gcode += this->extrude_entity(*fill, "infill");
-        }
+				std::cout<<"extrude ExtrusionEntityCollection:"<<chained.name<<"\n";
+        gcode += extrude_infill(print, chained);
     }
+    return gcode;
+}
+
+std::string GCode::extrude_infill(const Print &print, const ExtrusionEntityCollection &collection)
+{
+    std::string gcode;
+	std::cout<<"extrude collection:"<<collection.name<<"\n";
+
+	ExtrusionEntityCollection chained;
+	if(collection.no_sort) chained = collection;
+	else chained = collection.chained_path_from(m_last_pos, false);
+	for (ExtrusionEntity *fill : chained.entities) {
+		auto *eec = dynamic_cast<ExtrusionEntityCollection*>(fill);
+		if (eec) {
+			extrude_infill(print, *eec);
+		} else
+			gcode += this->extrude_entity(*fill, "infill");
+	}
     return gcode;
 }
 

--- a/xs/src/libslic3r/GCode.hpp
+++ b/xs/src/libslic3r/GCode.hpp
@@ -213,6 +213,7 @@ protected:
     };
     std::string     extrude_perimeters(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region, std::unique_ptr<EdgeGrid::Grid> &lower_layer_edge_grid);
     std::string     extrude_infill(const Print &print, const std::vector<ObjectByExtruder::Island::Region> &by_region);
+    std::string     extrude_infill(const Print &print, const ExtrusionEntityCollection &collection); // recursive extrude_infill
     std::string     extrude_support(const ExtrusionEntityCollection &support_fills);
 
     std::string     travel_to(const Point &point, ExtrusionRole role, std::string comment);

--- a/xs/src/libslic3r/PerimeterGenerator.cpp
+++ b/xs/src/libslic3r/PerimeterGenerator.cpp
@@ -54,9 +54,9 @@ PerimeterGenerator::process()
     for (const Surface &surface : this->slices->surfaces) {
         // detect how many perimeters must be generated for this island
         const int loop_number =  (config->only_one_perimeter_top && surface.is_external() && !surface.is_bridge() && surface.surface_type == stTop) ? 
-			0 : // only 1 perimeter for top surface if the option is set (0-indexed loops)
-			(this->config->perimeters + surface.extra_perimeters -1);  // normal case (0-indexed loops)
-		
+            0 : // only 1 perimeter for top surface if the option is set (0-indexed loops)
+            (this->config->perimeters + surface.extra_perimeters -1);  // normal case (0-indexed loops)
+        
         Polygons gaps;
         
         Polygons last = surface.expolygon.simplify_p(SCALED_RESOLUTION);

--- a/xs/src/libslic3r/PerimeterGenerator.cpp
+++ b/xs/src/libslic3r/PerimeterGenerator.cpp
@@ -53,8 +53,10 @@ PerimeterGenerator::process()
     // extra perimeters for each one
     for (const Surface &surface : this->slices->surfaces) {
         // detect how many perimeters must be generated for this island
-        const int loop_number = this->config->perimeters + surface.extra_perimeters -1;  // 0-indexed loops
-        
+        const int loop_number =  (config->only_one_perimeter_top && surface.is_external() && !surface.is_bridge() && surface.surface_type == stTop) ? 
+			0 : // only 1 perimeter for top surface if the option is set (0-indexed loops)
+			(this->config->perimeters + surface.extra_perimeters -1);  // normal case (0-indexed loops)
+		
         Polygons gaps;
         
         Polygons last = surface.expolygon.simplify_p(SCALED_RESOLUTION);

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -522,6 +522,7 @@ PrintConfigDef::PrintConfigDef()
     def->max = 100;
     def->enum_values.push_back("0");
     def->enum_values.push_back("5");
+    def->enum_values.push_back("7.5");
     def->enum_values.push_back("10");
     def->enum_values.push_back("15");
     def->enum_values.push_back("20");
@@ -536,6 +537,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("100");
     def->enum_labels.push_back("0%");
     def->enum_labels.push_back("5%");
+    def->enum_labels.push_back("7.5%");
     def->enum_labels.push_back("10%");
     def->enum_labels.push_back("15%");
     def->enum_labels.push_back("20%");
@@ -566,6 +568,8 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("honeycomb");
     def->enum_values.push_back("3dhoneycomb");
     def->enum_values.push_back("gyroid");
+    def->enum_values.push_back("gyroidthin");
+    def->enum_values.push_back("gyroidthick");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
@@ -579,6 +583,8 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("Honeycomb");
     def->enum_labels.push_back("3D Honeycomb");
     def->enum_labels.push_back("Gyroid");
+    def->enum_labels.push_back("Thin Gyroid");
+    def->enum_labels.push_back("Thick Gyroid");
     def->enum_labels.push_back("Hilbert Curve");
     def->enum_labels.push_back("Archimedean Chords");
     def->enum_labels.push_back("Octagram Spiral");

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -238,12 +238,11 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "ensure-vertical-shell-thickness!";
     def->default_value = new ConfigOptionBool(false);
 
-    def = this->add("external_fill_pattern", coEnum);
-    def->label = "Top/bottom fill pattern";
+    def = this->add("top_fill_pattern", coEnum);
+    def->label = "Top fill pattern";
     def->category = "Infill";
-    def->tooltip = "Fill pattern for top/bottom infill. This only affects the external visible layer, "
-                   "and not its adjacent solid shells.";
-    def->cli = "external-fill-pattern|solid-fill-pattern=s";
+    def->tooltip = "Fill pattern for top infill. This only affects the top external visible layer, and not its adjacent solid shells.";
+    def->cli = "top-fill-pattern|solid-fill-pattern=s";
     def->enum_keys_map = &ConfigOptionEnum<InfillPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
     def->enum_values.push_back("concentric");
@@ -257,6 +256,24 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("Octagram Spiral");
     // solid_fill_pattern is an obsolete equivalent to external_fill_pattern.
     def->aliases.push_back("solid_fill_pattern");
+    def->default_value = new ConfigOptionEnum<InfillPattern>(ipRectilinear);
+
+    def = this->add("bottom_fill_pattern", coEnum);
+    def->label = "bottom fill pattern";
+    def->category = "Infill";
+    def->tooltip = "Fill pattern for bottom infill. This only affects the bottom external visible layer, and not its adjacent solid shells.";
+    def->cli = "bottom-fill-pattern|solid-fill-pattern=s";
+    def->enum_keys_map = ConfigOptionEnum<InfillPattern>::get_enum_values();
+    def->enum_values.push_back("rectilinear");
+    def->enum_values.push_back("concentric");
+    def->enum_values.push_back("hilbertcurve");
+    def->enum_values.push_back("archimedeanchords");
+    def->enum_values.push_back("octagramspiral");
+    def->enum_labels.push_back("Rectilinear");
+    def->enum_labels.push_back("Concentric");
+    def->enum_labels.push_back("Hilbert Curve");
+    def->enum_labels.push_back("Archimedean Chords");
+    def->enum_labels.push_back("Octagram Spiral");
     def->default_value = new ConfigOptionEnum<InfillPattern>(ipRectilinear);
 
     def = this->add("external_perimeter_extrusion_width", coFloatOrPercent);

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -251,7 +251,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
     def->enum_labels.push_back("Rectilinear");
-    def->enum_labels.push_back("Smooth");
+    def->enum_labels.push_back("Ironing");
     def->enum_labels.push_back("Concentric");
     def->enum_labels.push_back("Hilbert Curve");
     def->enum_labels.push_back("Archimedean Chords");
@@ -265,7 +265,7 @@ PrintConfigDef::PrintConfigDef()
     def->category = "Infill";
     def->tooltip = "Fill pattern for bottom infill. This only affects the bottom external visible layer, and not its adjacent solid shells.";
     def->cli = "bottom-fill-pattern|solid-fill-pattern=s";
-    def->enum_keys_map = ConfigOptionEnum<InfillPattern>::get_enum_values();
+    def->enum_keys_map = &ConfigOptionEnum<InfillPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
     def->enum_values.push_back("concentric");
     def->enum_values.push_back("hilbertcurve");
@@ -576,8 +576,6 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("honeycomb");
     def->enum_values.push_back("3dhoneycomb");
     def->enum_values.push_back("gyroid");
-    def->enum_values.push_back("gyroidthin");
-    def->enum_values.push_back("gyroidthick");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
@@ -591,8 +589,6 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("Honeycomb");
     def->enum_labels.push_back("3D Honeycomb");
     def->enum_labels.push_back("Gyroid");
-    def->enum_labels.push_back("Thin Gyroid");
-    def->enum_labels.push_back("Thick Gyroid");
     def->enum_labels.push_back("Hilbert Curve");
     def->enum_labels.push_back("Archimedean Chords");
     def->enum_labels.push_back("Octagram Spiral");
@@ -1974,9 +1970,13 @@ std::string FullPrintConfig::validate()
     if (! print_config_def.get("fill_pattern")->has_enum_value(this->fill_pattern.serialize()))
         return "Invalid value for --fill-pattern";
     
-    // --external-fill-pattern
-    if (! print_config_def.get("external_fill_pattern")->has_enum_value(this->external_fill_pattern.serialize()))
-        return "Invalid value for --external-fill-pattern";
+    // --top-fill-pattern
+    if (! print_config_def.get("top_fill_pattern")->has_enum_value(this->top_fill_pattern.serialize()))
+        return "Invalid value for --top-fill-pattern";
+    
+    // --bottom-fill-pattern
+    if (! print_config_def.get("bottom_fill_pattern")->has_enum_value(this->bottom_fill_pattern.serialize()))
+        return "Invalid value for --bottom-fill-pattern";
 
     // --fill-density
     if (fabs(this->fill_density.value - 100.) < EPSILON &&

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -316,7 +316,7 @@ PrintConfigDef::PrintConfigDef()
                    "is supported.";
     def->cli = "extra-perimeters!";
     def->default_value = new ConfigOptionBool(true);
-	
+    
     def = this->add("only_one_perimeter_top", coBool);
     def->label = "Only one perimeter on Top surfaces";
     def->category = "Layers and Perimeters";

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -316,6 +316,14 @@ PrintConfigDef::PrintConfigDef()
                    "is supported.";
     def->cli = "extra-perimeters!";
     def->default_value = new ConfigOptionBool(true);
+	
+    def = this->add("only_one_perimeter_top", coBool);
+    def->label = "Only one perimeter on Top surfaces";
+    def->category = "Layers and Perimeters";
+    def->tooltip = "Use only one perimeter on flat top surface, to let more space to the top infill pattern.";
+    def->cli = "one-top-perimeters!";
+    def->default_value = new ConfigOptionBool(true);
+
 
     def = this->add("extruder", coInt);
     def->gui_type = "i_enum_open";

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -565,6 +565,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("concentric");
     def->enum_values.push_back("honeycomb");
     def->enum_values.push_back("3dhoneycomb");
+    def->enum_values.push_back("gyroid");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
@@ -577,6 +578,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("Concentric");
     def->enum_labels.push_back("Honeycomb");
     def->enum_labels.push_back("3D Honeycomb");
+    def->enum_labels.push_back("Gyroid");
     def->enum_labels.push_back("Hilbert Curve");
     def->enum_labels.push_back("Archimedean Chords");
     def->enum_labels.push_back("Octagram Spiral");

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -245,11 +245,13 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "top-fill-pattern|solid-fill-pattern=s";
     def->enum_keys_map = &ConfigOptionEnum<InfillPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
+    def->enum_values.push_back("smooth");
     def->enum_values.push_back("concentric");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
     def->enum_labels.push_back("Rectilinear");
+    def->enum_labels.push_back("Smooth");
     def->enum_labels.push_back("Concentric");
     def->enum_labels.push_back("Hilbert Curve");
     def->enum_labels.push_back("Archimedean Chords");

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -29,7 +29,7 @@ enum GCodeFlavor {
 
 enum InfillPattern {
     ipRectilinear, ipSmooth, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb, ipGyroid,
-    ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
+    ipGyroidThin, ipGyroidThick, ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
 };
 
 enum SupportMaterialPattern {

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -386,6 +386,7 @@ public:
     ConfigOptionFloatOrPercent      external_perimeter_speed;
     ConfigOptionBool                external_perimeters_first;
     ConfigOptionBool                extra_perimeters;
+    ConfigOptionBool                only_one_perimeter_top;
     ConfigOptionFloat               fill_angle;
     ConfigOptionPercent             fill_density;
     ConfigOptionEnum<InfillPattern> fill_pattern;
@@ -425,6 +426,7 @@ protected:
         OPT_PTR(external_perimeter_speed);
         OPT_PTR(external_perimeters_first);
         OPT_PTR(extra_perimeters);
+        OPT_PTR(only_one_perimeter_top);
         OPT_PTR(fill_angle);
         OPT_PTR(fill_density);
         OPT_PTR(fill_pattern);

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -378,7 +378,8 @@ public:
     ConfigOptionFloat               bridge_flow_ratio;
     ConfigOptionFloat               bridge_speed;
     ConfigOptionBool                ensure_vertical_shell_thickness;
-    ConfigOptionEnum<InfillPattern> external_fill_pattern;
+    ConfigOptionEnum<InfillPattern> top_fill_pattern;
+    ConfigOptionEnum<InfillPattern> bottom_fill_pattern;
     ConfigOptionFloatOrPercent      external_perimeter_extrusion_width;
     ConfigOptionFloatOrPercent      external_perimeter_speed;
     ConfigOptionBool                external_perimeters_first;
@@ -416,7 +417,8 @@ protected:
         OPT_PTR(bridge_flow_ratio);
         OPT_PTR(bridge_speed);
         OPT_PTR(ensure_vertical_shell_thickness);
-        OPT_PTR(external_fill_pattern);
+        OPT_PTR(top_fill_pattern);
+        OPT_PTR(bottom_fill_pattern);
         OPT_PTR(external_perimeter_extrusion_width);
         OPT_PTR(external_perimeter_speed);
         OPT_PTR(external_perimeters_first);

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -29,7 +29,7 @@ enum GCodeFlavor {
 
 enum InfillPattern {
     ipRectilinear, ipSmooth, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb, ipGyroid,
-    ipGyroidThin, ipGyroidThick, ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
+    ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
 };
 
 enum SupportMaterialPattern {
@@ -65,7 +65,7 @@ template<> inline t_config_enum_values& ConfigOptionEnum<InfillPattern>::get_enu
     static t_config_enum_values keys_map;
     if (keys_map.empty()) {
         keys_map["rectilinear"]         = ipRectilinear;
-        keys_map["smooth"]              = ipSmooth;
+        keys_map["smooth"]             = ipSmooth;
         keys_map["grid"]                = ipGrid;
         keys_map["triangles"]           = ipTriangles;
         keys_map["stars"]               = ipStars;

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -28,7 +28,7 @@ enum GCodeFlavor {
 };
 
 enum InfillPattern {
-    ipRectilinear, ipSmooth, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb,
+    ipRectilinear, ipSmooth, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb, ipGyroid,
     ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
 };
 
@@ -74,6 +74,7 @@ template<> inline t_config_enum_values& ConfigOptionEnum<InfillPattern>::get_enu
         keys_map["concentric"]          = ipConcentric;
         keys_map["honeycomb"]           = ipHoneycomb;
         keys_map["3dhoneycomb"]         = ip3DHoneycomb;
+        keys_map["gyroid"]              = ipGyroid;
         keys_map["hilbertcurve"]        = ipHilbertCurve;
         keys_map["archimedeanchords"]   = ipArchimedeanChords;
         keys_map["octagramspiral"]      = ipOctagramSpiral;

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -28,7 +28,7 @@ enum GCodeFlavor {
 };
 
 enum InfillPattern {
-    ipRectilinear, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb,
+    ipRectilinear, ipSmooth, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb,
     ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral,
 };
 
@@ -65,6 +65,7 @@ template<> inline t_config_enum_values& ConfigOptionEnum<InfillPattern>::get_enu
     static t_config_enum_values keys_map;
     if (keys_map.empty()) {
         keys_map["rectilinear"]         = ipRectilinear;
+        keys_map["smooth"]              = ipSmooth;
         keys_map["grid"]                = ipGrid;
         keys_map["triangles"]           = ipTriangles;
         keys_map["stars"]               = ipStars;

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -198,7 +198,8 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "bridge_angle") {
             steps.emplace_back(posPrepareInfill);
         } else if (
-               opt_key == "external_fill_pattern"
+               opt_key == "top_fill_pattern"
+            || opt_key == "bottom_fill_pattern"
             || opt_key == "external_fill_link_max_length"
             || opt_key == "fill_angle"
             || opt_key == "fill_pattern"

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -1438,6 +1438,8 @@ void PrintObject::_make_perimeters()
 {
     if (this->state.is_done(posPerimeters)) return;
     this->state.set_started(posPerimeters);
+	
+	
 
     BOOST_LOG_TRIVIAL(info) << "Generating perimeters...";
     
@@ -1448,6 +1450,16 @@ void PrintObject::_make_perimeters()
         this->typed_slices = false;
         this->state.invalidate(posPrepareInfill);
     }
+	
+	//if we want only one perimeter for each top surface, we need to know who is a top surface before the infill
+	// ! detect_surfaces_type is done is every case in the infill() call chain.
+	if(_print->default_region_config.only_one_perimeter_top){
+		// This will assign a type (top/bottom/internal) to $layerm->slices.
+		// Then the classifcation of $layerm->slices is transfered onto 
+		// the $layerm->fill_surfaces by clipping $layerm->fill_surfaces
+		// by the cummulative area of the previous $layerm->fill_surfaces.
+		this->detect_surfaces_type();
+	}
     
     // compare each layer to the one below, and mark those slices needing
     // one additional inner perimeter, like the top of domed objects-

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -155,9 +155,9 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "first_layer_height"
             || opt_key == "raft_layers") {
             steps.emplace_back(posSlice);
-			this->reset_layer_height_profile();
-		}
-		else if (
+            this->reset_layer_height_profile();
+        }
+        else if (
                opt_key == "clip_multipart_objects"
             || opt_key == "elefant_foot_compensation"
             || opt_key == "support_material_contact_distance" 
@@ -236,8 +236,8 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             // these options only affect G-code export, so nothing to invalidate
         } else {
             // for legacy, if we can't handle this option let's invalidate all steps
-			this->reset_layer_height_profile();
-			this->invalidate_all_steps();
+            this->reset_layer_height_profile();
+            this->invalidate_all_steps();
             invalidated = true;
         }
     }
@@ -751,8 +751,8 @@ void PrintObject::discover_vertical_shells()
                     PROFILE_BLOCK(discover_vertical_shells_region_layer);
 
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
-        			static size_t debug_idx = 0;
-        			++ debug_idx;
+                    static size_t debug_idx = 0;
+                    ++ debug_idx;
 #endif /* SLIC3R_DEBUG_SLICE_PROCESSING */
 
                     Layer       *layer               = this->layers[idx_layer];
@@ -777,13 +777,13 @@ void PrintObject::discover_vertical_shells()
 #if 0
 // #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                         {
-        					Slic3r::SVG svg_cummulative(debug_out_path("discover_vertical_shells-perimeters-before-union-run%d.svg", debug_idx), this->bounding_box());
+                            Slic3r::SVG svg_cummulative(debug_out_path("discover_vertical_shells-perimeters-before-union-run%d.svg", debug_idx), this->bounding_box());
                             for (int n = (int)idx_layer - n_extra_bottom_layers; n <= (int)idx_layer + n_extra_top_layers; ++ n) {
                                 if (n < 0 || n >= (int)this->layers.size())
                                     continue;
                                 ExPolygons &expolys = this->layers[n]->perimeter_expolygons;
                                 for (size_t i = 0; i < expolys.size(); ++ i) {
-        							Slic3r::SVG svg(debug_out_path("discover_vertical_shells-perimeters-before-union-run%d-layer%d-expoly%d.svg", debug_idx, n, i), get_extents(expolys[i]));
+                                    Slic3r::SVG svg(debug_out_path("discover_vertical_shells-perimeters-before-union-run%d-layer%d-expoly%d.svg", debug_idx, n, i), get_extents(expolys[i]));
                                     svg.draw(expolys[i]);
                                     svg.draw_outline(expolys[i].contour, "black", scale_(0.05));
                                     svg.draw_outline(expolys[i].holes, "blue", scale_(0.05));
@@ -823,7 +823,7 @@ void PrintObject::discover_vertical_shells()
                             }
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                         {
-        					Slic3r::SVG svg(debug_out_path("discover_vertical_shells-perimeters-before-union-%d.svg", debug_idx), get_extents(shell));
+                            Slic3r::SVG svg(debug_out_path("discover_vertical_shells-perimeters-before-union-%d.svg", debug_idx), get_extents(shell));
                             svg.draw(shell);
                             svg.draw_outline(shell, "black", scale_(0.05));
                             svg.Close(); 
@@ -950,8 +950,8 @@ void PrintObject::discover_vertical_shells()
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
                     {
                         SVG::export_expolygons(debug_out_path("discover_vertical_shells-new_internal-%d.svg", debug_idx), get_extents(shell), new_internal, "black", "blue", scale_(0.05));
-        				SVG::export_expolygons(debug_out_path("discover_vertical_shells-new_internal_void-%d.svg", debug_idx), get_extents(shell), new_internal_void, "black", "blue", scale_(0.05));
-        				SVG::export_expolygons(debug_out_path("discover_vertical_shells-new_internal_solid-%d.svg", debug_idx), get_extents(shell), new_internal_solid, "black", "blue", scale_(0.05));
+                        SVG::export_expolygons(debug_out_path("discover_vertical_shells-new_internal_void-%d.svg", debug_idx), get_extents(shell), new_internal_void, "black", "blue", scale_(0.05));
+                        SVG::export_expolygons(debug_out_path("discover_vertical_shells-new_internal_solid-%d.svg", debug_idx), get_extents(shell), new_internal_solid, "black", "blue", scale_(0.05));
                     }
 #endif /* SLIC3R_DEBUG_SLICE_PROCESSING */
 
@@ -966,11 +966,11 @@ void PrintObject::discover_vertical_shells()
         BOOST_LOG_TRIVIAL(debug) << "Discovering vertical shells for region " << idx_region << " in parallel - end";
 
 #ifdef SLIC3R_DEBUG_SLICE_PROCESSING
-		for (size_t idx_layer = 0; idx_layer < this->layers.size(); ++idx_layer) {
-			LayerRegion *layerm = this->layers[idx_layer]->get_region(idx_region);
-			layerm->export_region_slices_to_svg_debug("4_discover_vertical_shells-final");
-			layerm->export_region_fill_surfaces_to_svg_debug("4_discover_vertical_shells-final");
-		}
+        for (size_t idx_layer = 0; idx_layer < this->layers.size(); ++idx_layer) {
+            LayerRegion *layerm = this->layers[idx_layer]->get_region(idx_region);
+            layerm->export_region_slices_to_svg_debug("4_discover_vertical_shells-final");
+            layerm->export_region_fill_surfaces_to_svg_debug("4_discover_vertical_shells-final");
+        }
 #endif /* SLIC3R_DEBUG_SLICE_PROCESSING */
     } // for each region
 
@@ -1255,8 +1255,8 @@ void PrintObject::_slice()
                 goto end;
         delete layer;
         this->layers.pop_back();
-		if (! this->layers.empty())
-			this->layers.back()->upper_layer = nullptr;
+        if (! this->layers.empty())
+            this->layers.back()->upper_layer = nullptr;
     }
 end:
     ;
@@ -1283,11 +1283,11 @@ end:
                     // Multiple regions, growing, shrinking or just clipping one region by the other.
                     // When clipping the regions, priority is given to the first regions.
                     Polygons processed;
-        			for (size_t region_id = 0; region_id < layer->regions.size(); ++ region_id) {
+                    for (size_t region_id = 0; region_id < layer->regions.size(); ++ region_id) {
                         LayerRegion *layerm = layer->regions[region_id];
-        				ExPolygons slices = to_expolygons(std::move(layerm->slices.surfaces));
-        				if (scale)
-        					slices = offset_ex(slices, delta);
+                        ExPolygons slices = to_expolygons(std::move(layerm->slices.surfaces));
+                        if (scale)
+                            slices = offset_ex(slices, delta);
                         if (region_id > 0 && clip) 
                             // Trim by the slices of already processed regions.
                             slices = diff_ex(to_polygons(std::move(slices)), processed);
@@ -1438,8 +1438,8 @@ void PrintObject::_make_perimeters()
 {
     if (this->state.is_done(posPerimeters)) return;
     this->state.set_started(posPerimeters);
-	
-	
+    
+    
 
     BOOST_LOG_TRIVIAL(info) << "Generating perimeters...";
     
@@ -1450,16 +1450,16 @@ void PrintObject::_make_perimeters()
         this->typed_slices = false;
         this->state.invalidate(posPrepareInfill);
     }
-	
-	//if we want only one perimeter for each top surface, we need to know who is a top surface before the infill
-	// ! detect_surfaces_type is done is every case in the infill() call chain.
-	if(_print->default_region_config.only_one_perimeter_top){
-		// This will assign a type (top/bottom/internal) to $layerm->slices.
-		// Then the classifcation of $layerm->slices is transfered onto 
-		// the $layerm->fill_surfaces by clipping $layerm->fill_surfaces
-		// by the cummulative area of the previous $layerm->fill_surfaces.
-		this->detect_surfaces_type();
-	}
+    
+    //if we want only one perimeter for each top surface, we need to know who is a top surface before the infill
+    // ! detect_surfaces_type is done is every case in the infill() call chain.
+    if(_print->default_region_config.only_one_perimeter_top){
+        // This will assign a type (top/bottom/internal) to $layerm->slices.
+        // Then the classifcation of $layerm->slices is transfered onto 
+        // the $layerm->fill_surfaces by clipping $layerm->fill_surfaces
+        // by the cummulative area of the previous $layerm->fill_surfaces.
+        this->detect_surfaces_type();
+    }
     
     // compare each layer to the one below, and mark those slices needing
     // one additional inner perimeter, like the top of domed objects-
@@ -1833,7 +1833,7 @@ void PrintObject::discover_horizontal_shells()
                             // Use an existing surface as a template, it carries the bridge angle etc.
                             *group.front());
                 }
-		EXTERNAL:;
+        EXTERNAL:;
             } // foreach type (stTop, stBottom, stBottomBridge)
         } // for each layer
     } // for each region
@@ -1894,12 +1894,12 @@ void PrintObject::combine_infill()
         // loop through layers to which we have assigned layers to combine
         for (size_t layer_idx = 0; layer_idx < this->layers.size(); ++ layer_idx) {
             size_t num_layers = combine[layer_idx];
-			if (num_layers <= 1)
+            if (num_layers <= 1)
                 continue;
             // Get all the LayerRegion objects to be combined.
             std::vector<LayerRegion*> layerms;
             layerms.reserve(num_layers);
-			for (size_t i = layer_idx + 1 - num_layers; i <= layer_idx; ++ i)
+            for (size_t i = layer_idx + 1 - num_layers; i <= layer_idx; ++ i)
                 layerms.emplace_back(this->layers[i]->regions[region_id]);
             // We need to perform a multi-layer intersection, so let's split it in pairs.
             // Initialize the intersection with the candidates of the lowest layer.
@@ -1969,7 +1969,7 @@ void PrintObject::reset_layer_height_profile()
 {
     // Reset the layer_heigth_profile.
     this->layer_height_profile.clear();
-	this->layer_height_profile_valid = false;
+    this->layer_height_profile_valid = false;
     // Reset the source layer_height_profile if it exists at the ModelObject.
     this->model_object()->layer_height_profile.clear();
     this->model_object()->layer_height_profile_valid = false;

--- a/xs/src/slic3r/GUI/Preset.cpp
+++ b/xs/src/slic3r/GUI/Preset.cpp
@@ -180,7 +180,7 @@ const std::vector<std::string>& Preset::print_options()
     static std::vector<std::string> s_opts {
         "layer_height", "first_layer_height", "perimeters", "spiral_vase", "top_solid_layers", "bottom_solid_layers", 
         "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs", 
-        "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "external_fill_pattern", 
+        "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern", 
         "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle", 
         "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", "max_print_speed", 
         "max_volumetric_speed", "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative", 
@@ -199,7 +199,7 @@ const std::vector<std::string>& Preset::print_options()
         "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width", 
         "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "bridge_flow_ratio", "clip_multipart_objects", 
         "elefant_foot_compensation", "xy_size_compensation", "threads", "resolution", "wipe_tower", "wipe_tower_x", "wipe_tower_y",
-        "wipe_tower_width", "wipe_tower_per_color_wipe",
+        "wipe_tower_width", "wipe_tower_per_color_wipe", "only_one_perimeter_top",
         "compatible_printers", "compatible_printers_condition"
     };
     return s_opts;


### PR DESCRIPTION
I can make 3 separate pull request if needed.

**Functionalities**

- neosanding : 
work well but may lead in overextruding in some edge case (not worth the hassle i think)
Use the top layer speed for the first pass (90%extrusion, 100%width)
Use the infill speed for the second pass (15%extrusion, 50%width)
 => 120% extrusion flow but it create gaps if I reduced it.

- 1 top perimeter
It's useful combined with neosanding to have almost all the surface with the nice smooth finish

- gyroid infill
It's slow to compute, I have to work a bit to optimize the algorithm (like caching). But it's usesable right now.

When the gui revamp will be finish, maybe I will try to add parameters to infills to add some options (like thick/thin lines, % of overextruding for neosanding, neosanding speed...)

**Implementation**

- gyroid is just an other infill. There are 3 presets, the thin one is used in this pull request. I'm working on testing the compression strength, to decide what is the best.

- 1 top perimeter: 
A if in the perimeterGenerator.cpp. Also use an early call to detect_surfaces_type() to know if it's on top.

- neosanding:
I  move some logic from Fill.cpp to the base class Fill from BaseFill.cpp.
Now, if they want, the infill algorithm can create an ExtrusionEntityCollection instead of just a Polylines.
Also, if an ExtrusionEntityCollection is set to not be sorted, it will really not be sorted (only for infill). I've added and modified the necessary methods in gcode.cpp, and added a flattenIfSortable method to ExtrusionEntityCollection for that (i don't know but it seem the flatten method is not used).

Also, i split the "external infill" to top and bottom (to allow smooth top only). The presets files have to change to reflect this (i think, there's an error message at the first startup).

**other**

i use "neosanding" as label for the smooth top infill because someone complain about "smooth". Call it as you want, i don't mind.

As i split 

note:I made a pass to replace all \t by '     ' in the file I modified, sometimes it changed some pre-existent \t.
note2: remi, merill and supermerill are me (i use merill when possible, i use 'supermerill' when it's already taken) but on different computers. 

#475
#458 
#92
#65 