### PR TITLE
Fix format-security violations

### DIFF
--- a/xs/xsp/GCode.xsp
+++ b/xs/xsp/GCode.xsp
@@ -23,7 +23,7 @@
             try {
                 THIS->do_export(print, path);
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};
     void do_export_w_preview(Print *print, const char *path, GCodePreviewData *preview_data)

--- a/xs/xsp/PlaceholderParser.xsp
+++ b/xs/xsp/PlaceholderParser.xsp
@@ -18,7 +18,7 @@
             try {
                 RETVAL = THIS->process(str, 0);
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};
 
@@ -27,7 +27,7 @@
             try {
                 RETVAL = THIS->evaluate_boolean_expression(str, THIS->config());
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};        
 };

--- a/xs/xsp/Print.xsp
+++ b/xs/xsp/Print.xsp
@@ -212,7 +212,7 @@ _constant()
             try {
                 RETVAL = THIS->output_filepath(path);
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};
     


### PR DESCRIPTION
croak() expects printf-style format strings. Calling croak(e.what()) directly
causes compilations to fail with -Werror=format-security

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892959 for more information.