### PR TITLE
Bugfixes for 1.40.1 

### DIFF
--- a/xs/src/slic3r/GUI/ConfigWizard.cpp
+++ b/xs/src/slic3r/GUI/ConfigWizard.cpp
@@ -83,8 +83,11 @@ PrinterPicker::PrinterPicker(wxWindow *parent, const VendorProfile &vendor, cons
 
 		const auto model_id = model.id;
 
+		bool default_variant = true;   // Mark the first variant as default in the GUI
 		for (const auto &variant : model.variants) {
-			const auto label = wxString::Format("%s %s %s", variant.name, _(L("mm")), _(L("nozzle")));
+			const auto label = wxString::Format("%s %s %s %s", variant.name, _(L("mm")), _(L("nozzle")),
+				(default_variant ? _(L("(default)")) : wxString()));
+			default_variant = false;
 			auto *cbox = new Checkbox(panel, label, model_id, variant.name);
 			const size_t idx = cboxes.size();
 			cboxes.push_back(cbox);

--- a/xs/src/slic3r/GUI/ConfigWizard.cpp
+++ b/xs/src/slic3r/GUI/ConfigWizard.cpp
@@ -113,11 +113,6 @@ PrinterPicker::PrinterPicker(wxWindow *parent, const VendorProfile &vendor, cons
 	sizer->Add(all_none_sizer, 0, wxEXPAND);
 
 	SetSizer(sizer);
-
-	if (cboxes.size() > 0) {
-		cboxes[0]->SetValue(true);
-		on_checkbox(cboxes[0], true);
-	}
 }
 
 void PrinterPicker::select_all(bool select)
@@ -127,6 +122,14 @@ void PrinterPicker::select_all(bool select)
 			cb->SetValue(select);
 			on_checkbox(cb, select);
 		}
+	}
+}
+
+void PrinterPicker::select_one(size_t i, bool select)
+{
+	if (i < cboxes.size() && cboxes[i]->GetValue() != select) {
+		cboxes[i]->SetValue(select);
+		on_checkbox(cboxes[i], select);
 	}
 }
 
@@ -232,6 +235,7 @@ PageWelcome::PageWelcome(ConfigWizard *parent) :
 		AppConfig &appconfig_vendors = this->wizard_p()->appconfig_vendors;
 
 		printer_picker = new PrinterPicker(this, vendor_prusa->second, appconfig_vendors);
+		printer_picker->select_one(0, true);    // Select the default (first) model/variant on the Prusa vendor
 		printer_picker->Bind(EVT_PRINTER_PICK, [this, &appconfig_vendors](const PrinterPickerEvent &evt) {
 			appconfig_vendors.set_variant(evt.vendor_id, evt.model_id, evt.variant_name, evt.enable);
 			this->on_variant_checked();

--- a/xs/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/xs/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -56,6 +56,7 @@ struct PrinterPicker: wxPanel
 	PrinterPicker(wxWindow *parent, const VendorProfile &vendor, const AppConfig &appconfig_vendors);
 
 	void select_all(bool select);
+	void select_one(size_t i, bool select);
 	void on_checkbox(const Checkbox *cbox, bool checked);
 };
 

--- a/xs/src/slic3r/Utils/Http.cpp
+++ b/xs/src/slic3r/Utils/Http.cpp
@@ -71,6 +71,7 @@ Http::priv::priv(const std::string &url) :
 	form(nullptr),
 	form_end(nullptr),
 	headerlist(nullptr),
+	limit(0),
 	cancel(false)
 {
 	if (curl == nullptr) {

--- a/xs/src/slic3r/Utils/Http.hpp
+++ b/xs/src/slic3r/Utils/Http.hpp
@@ -46,7 +46,8 @@ public:
 	Http& operator=(const Http &) = delete;
 	Http& operator=(Http &&) = delete;
 
-	// Sets a maximum size of the data that can be received. The default is 5MB.
+	// Sets a maximum size of the data that can be received.
+	// A value of zero sets the default limit, which is is 5MB.
 	Http& size_limit(size_t sizeLimit);
 	// Sets a HTTP header field.
 	Http& header(std::string name, const std::string &value);

--- a/xs/src/slic3r/Utils/PresetUpdater.cpp
+++ b/xs/src/slic3r/Utils/PresetUpdater.cpp
@@ -537,15 +537,15 @@ bool PresetUpdater::config_update() const
 			incompats_map.emplace(std::make_pair(std::move(vendor), std::move(restrictions)));
 		}
 
+		p->had_config_update = true;   // This needs to be done before a dialog is shown because of OnIdle() + CallAfter() in Perl
+
 		GUI::MsgDataIncompatible dlg(std::move(incompats_map));
 		const auto res = dlg.ShowModal();
 		if (res == wxID_REPLACE) {
 			BOOST_LOG_TRIVIAL(info) << "User wants to re-configure...";
 			p->perform_updates(std::move(updates));
 			GUI::ConfigWizard wizard(nullptr, GUI::ConfigWizard::RR_DATA_INCOMPAT);
-			if (wizard.run(GUI::get_preset_bundle(), this)) {
-				p->had_config_update = true;
-			} else {
+			if (! wizard.run(GUI::get_preset_bundle(), this)) {	
 				return false;
 			}
 		} else {
@@ -566,6 +566,8 @@ bool PresetUpdater::config_update() const
 			updates_map.emplace(std::make_pair(std::move(vendor), std::move(ver_str)));
 		}
 
+		p->had_config_update = true;   // Ditto, see above
+
 		GUI::MsgUpdateConfig dlg(std::move(updates_map));
 
 		const auto res = dlg.ShowModal();
@@ -581,8 +583,6 @@ bool PresetUpdater::config_update() const
 		} else {
 			BOOST_LOG_TRIVIAL(info) << "User refused the update";
 		}
-
-		p->had_config_update = true;
 	} else {
 		BOOST_LOG_TRIVIAL(info) << "No configuration updates available.";
 	}


### PR DESCRIPTION
- Fix ConfigWizard activating testing vendors
- Fix PresetUpdater displaying profile update _and_ application update on top of each other
- In ConfigWizard, append a `(default)` label to the first variant of each printer model to make some of the users less confused
- Fix #1008 