### PR TITLE
Adjust the last layer to align with the top object layer exactly

### DIFF
--- a/xs/src/libslic3r/Slicing.cpp
+++ b/xs/src/libslic3r/Slicing.cpp
@@ -216,6 +216,7 @@ std::vector<coordf_t> layer_height_profile_from_ranges(
 
 // Based on the work of @platsch
 // Fill layer_height_profile by heights ensuring a prescribed maximum cusp height.
+// @Deprecated not used anymore (see PrintObject::update_layer_height_profile)
 std::vector<coordf_t> layer_height_profile_adaptive(
     const SlicingParameters     &slicing_params,
     const t_layer_height_ranges &layer_height_ranges,
@@ -551,7 +552,34 @@ std::vector<coordf_t> generate_object_layers(
         out.push_back(print_z);
     }
 
-    //FIXME Adjust the last layer to align with the top object layer exactly?
+    // Adjust the last layer to align with the top object layer exactly
+    if (out.size() > 0 && slicing_params.object_print_z_height() != out[out.size()-1]){
+        float neededPrintZ = slicing_params.object_print_z_height();
+        int idx_layer = out.size() / 2 - 1;
+        float diffZ = neededPrintZ - out[idx_layer * 2 + 1];
+        while (diffZ > EPSILON || diffZ < -EPSILON && idx_layer >= 0){
+            float newH = out[idx_layer * 2 + 1] - out[idx_layer * 2];
+            if (diffZ > 0){
+                newH = std::min((float)slicing_params.max_layer_height, newH + diffZ);
+            } else{
+                newH = std::max((float)slicing_params.min_layer_height, newH + diffZ);
+            }
+            out[idx_layer * 2 + 1] = neededPrintZ;
+            out[idx_layer * 2] = neededPrintZ - newH;
+
+            //next item
+            neededPrintZ = out[idx_layer * 2];
+            idx_layer--;
+            if (idx_layer >= 0){
+                diffZ = neededPrintZ - out[idx_layer * 2 + 1];
+            } else{
+                //unlikely to happen. note: can create a layer outside the min/max bounds. 
+                diffZ = 0;
+                out[idx_layer * 2] = 0;
+            }
+        }
+    }
+
     return out;
 }
 


### PR DESCRIPTION
Create a little algo under the "//FIXME Adjust the last layer to align with the top object layer exactly"

Now, when we use the layer editing, the last layer is printed at the exact end height of the object.
It keeps the bounds of the layers inside the min/max settings.

note: it doesn't work for all top surfaces, only the object height (better than nothing). I will try to see if it can be improved (unlikely).