### PR TITLE
Fixed Matrix4x4 vector alignment for AVX instructions

### DIFF
--- a/xs/src/libslic3r/Format/3mf.cpp
+++ b/xs/src/libslic3r/Format/3mf.cpp
@@ -9,6 +9,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/align/aligned_allocator.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/nowide/fstream.hpp>
 
@@ -319,7 +320,7 @@ namespace Slic3r {
 
         typedef std::map<int, ModelObject*> IdToModelObjectMap;
         typedef std::map<int, ComponentsList> IdToAliasesMap;
-        typedef std::vector<Instance> InstancesList;
+        typedef std::vector<Instance, boost::alignment::aligned_allocator<Instance, 16>> InstancesList;
         typedef std::map<int, ObjectMetadata> IdToMetadataMap;
         typedef std::map<int, Geometry> IdToGeometryMap;
         typedef std::map<int, std::vector<coordf_t>> IdToLayerHeightsProfileMap;


### PR DESCRIPTION
When compiled with AVX-enabling flags (-mavx, -mavx2), 3MF import
was generating segmentation faults at the line where InstancesList
was being emplaced to.