### PR TITLE
duet upload: allow whitespaces in filenames

### DIFF
--- a/xs/src/slic3r/Utils/Duet.cpp
+++ b/xs/src/slic3r/Utils/Duet.cpp
@@ -8,6 +8,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #include <wx/frame.h>
 #include <wx/event.h>
@@ -197,7 +198,7 @@ std::string Duet::get_upload_url(const std::string &filename) const
 {
 	return (boost::format("%1%rr_upload?name=0:/gcodes/%2%&%3%")
 			% get_base_url()
-			% filename 
+			% Http::url_encode(filename) 
 			% timestamp_str()).str();
 }
 
@@ -248,9 +249,10 @@ wxString Duet::format_error(const std::string &body, const std::string &error, u
 bool Duet::start_print(wxString &msg, const std::string &filename) const 
 {
 	bool res = false;
+	
 	auto url = (boost::format("%1%rr_gcode?gcode=M32%%20\"%2%\"")
 			% get_base_url()
-			% filename).str();
+			% Http::url_encode(filename)).str();
 
 	auto http = Http::get(std::move(url));
 	http.on_error([&](std::string body, std::string error, unsigned status) {
@@ -274,6 +276,5 @@ int Duet::get_err_code_from_body(const std::string &body) const
 
 	return root.get<int>("err", 0);
 }
-
 
 }

--- a/xs/src/slic3r/Utils/Duet.cpp
+++ b/xs/src/slic3r/Utils/Duet.cpp
@@ -8,7 +8,6 @@
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/algorithm/string/replace.hpp>
 
 #include <wx/frame.h>
 #include <wx/event.h>

--- a/xs/src/slic3r/Utils/Http.cpp
+++ b/xs/src/slic3r/Utils/Http.cpp
@@ -424,11 +424,14 @@ bool Http::ca_file_supported()
 std::string Http::url_encode(const std::string &str)
 {
 	::CURL *curl = ::curl_easy_init();
+	if (curl == nullptr) {
+		return str;
+	}
 	char *ce = ::curl_easy_escape(curl, str.c_str(), str.length());
 	std::string encoded = std::string(ce);
 
 	::curl_free(ce);
-	if (curl != nullptr) { ::curl_easy_cleanup(curl); }
+	::curl_easy_cleanup(curl);
 
 	return encoded;
 }

--- a/xs/src/slic3r/Utils/Http.cpp
+++ b/xs/src/slic3r/Utils/Http.cpp
@@ -421,6 +421,18 @@ bool Http::ca_file_supported()
 	return res;
 }
 
+std::string Http::url_encode(const std::string &str)
+{
+	::CURL *curl = ::curl_easy_init();
+	char *ce = ::curl_easy_escape(curl, str.c_str(), str.length());
+	std::string encoded = std::string(ce);
+
+	::curl_free(ce);
+	if (curl != nullptr) { ::curl_easy_cleanup(curl); }
+
+	return encoded;
+}
+
 std::ostream& operator<<(std::ostream &os, const Http::Progress &progress)
 {
 	os << "Http::Progress("

--- a/xs/src/slic3r/Utils/Http.hpp
+++ b/xs/src/slic3r/Utils/Http.hpp
@@ -98,6 +98,9 @@ public:
 
 	// Tells whether current backend supports seting up a CA file using ca_file()
 	static bool ca_file_supported();
+
+	// converts the given string to an url_encoded_string
+	static std::string url_encode(const std::string &str);
 private:
 	Http(const std::string &url);
 


### PR DESCRIPTION
This PR allow whitespaces in filenames when uploading to Duet.

I've just replaced whitespaces with "%20".