### PR TITLE
fixing issue with disappearing tabs

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2321,7 +2321,11 @@ void Tab::load_current_preset()
                     if (tab->type() == Preset::TYPE_PRINTER) // Printer tab is shown every time
                         continue;
                     if (tab->supports_printer_technology(printer_technology))
+                    {
                         wxGetApp().tab_panel()->InsertPage(wxGetApp().tab_panel()->FindPage(this), tab, tab->title());
+                        int page_id = wxGetApp().tab_panel()->FindPage(tab);
+                        wxGetApp().tab_panel()->GetPage(page_id)->Show(true);
+                    }
                     else {
                         int page_id = wxGetApp().tab_panel()->FindPage(tab);
                         wxGetApp().tab_panel()->GetPage(page_id)->Show(false);


### PR DESCRIPTION
When switching from FFF->SLA or SLA->FFF once worked fine but when switching back to the original printer type it would make the printer type disappear.

This was tested on Linux on version_1.42.0-alpha1

Fix:
src/slic3r/GUI/Tab.cpp:
        When switch to previously created tabs they were not being
        restored