### PR TITLE
Replace undocumented (and missing) boost::to_string function with std::to_string

### DIFF
--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -34,7 +34,6 @@
 #define BOOST_RESULT_OF_USE_DECLTYPE
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/config/warning_disable.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_lit.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>


### PR DESCRIPTION
Replaces the use of the undocumented `boost::to_string` function (likely `boost::lexical_cast<std::string>` in disguise) with the new `std::to_string`, introduced in C++11 (since C++11 is now a build requirement).