### PR TITLE
Added conversion to standard string

### DIFF
--- a/src/slic3r/GUI/GLGizmo.cpp
+++ b/src/slic3r/GUI/GLGizmo.cpp
@@ -2273,7 +2273,7 @@ RENDER_AGAIN:
         m_combo_box_open = m_imgui->combo(_(L("Head diameter")), options, str);
         force_refresh |= (old_combo_state != m_combo_box_open);
 
-        float current_number = atof(str);
+        float current_number = atof(str.mb_str());
         if (old_combo_state && !m_combo_box_open) // closing the combo must always change the sizes (even if the selection did not change)
             for (auto& point_and_selection : m_editing_mode_cache)
                 if (point_and_selection.second) {


### PR DESCRIPTION
I tried to build the latest master (61f8e4f6f7f74d87c50e333c60751022d9a1a362) on Linux (x86_64) with "-DSLIC3R_WX_STABLE=1" which failed for me with:

`/home/shammerl/Workspace/Github/Slic3r_prusa/src/slic3r/GUI/GLGizmo.cpp:2276:40: error: cannot convert ‘wxString’ to ‘const char*’ for argument ‘1’ to ‘double atof(const char*)’ float current_number = atof(str);`

I converted the string, now it compiles. Perhaps there is a better solution, this one works for me.