### PR TITLE
Fix compile errors

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectSettings.hpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.hpp
@@ -2,6 +2,7 @@
 #define slic3r_GUI_ObjectSettings_hpp_
 
 #include <memory>
+#include <vector>
 #include <wx/panel.h>
 
 class wxBoxSizer;

--- a/src/slic3r/GUI/KBShortcutsDialog.hpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.hpp
@@ -3,6 +3,7 @@
 
 #include <wx/wx.h>
 #include <map>
+#include <vector>
 
 namespace Slic3r { 
 namespace GUI {


### PR DESCRIPTION
At least on my system (Fedora 28) gcc gave a compile error for std::vector being used despite being undefined in a couple of places.
Adding the appropriate include fixes the problem, and seems unlikely to cause any other problems.