### PR TITLE
Fix crash on splitting some models

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1467,11 +1467,7 @@ int ModelVolume::extruder_id() const
 
 bool ModelVolume::is_splittable() const
 {
-    // the call mesh.is_splittable() is expensive, so cache the value to calculate it only once
-    if (m_is_splittable == -1)
-        m_is_splittable = (int)mesh.is_splittable();
-
-    return m_is_splittable == 1;
+    return mesh.stl.stats.number_of_parts > 1;
 }
 
 void ModelVolume::center_geometry()

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -61,7 +61,7 @@ Model& Model::assign_copy(Model &&rhs)
 	this->objects = std::move(rhs.objects);
     for (ModelObject *model_object : this->objects)
         model_object->set_model(this);
-	rhs.objects.clear();
+    rhs.objects.clear();
     return *this;
 }
 
@@ -651,7 +651,7 @@ ModelObject& ModelObject::assign_copy(ModelObject &&rhs)
     for (ModelInstance *model_instance : this->instances)
         model_instance->set_model_object(this);
 
-	return *this;
+    return *this;
 }
 
 void ModelObject::assign_new_unique_ids_recursive()
@@ -970,8 +970,8 @@ Polygon ModelObject::convex_hull_2d(const Transform3d &trafo_instance)
                 }
             }
         }
-	std::sort(pts.begin(), pts.end(), [](const Point& a, const Point& b) { return a(0) < b(0) || (a(0) == b(0) && a(1) < b(1)); });
-	pts.erase(std::unique(pts.begin(), pts.end(), [](const Point& a, const Point& b) { return a(0) == b(0) && a(1) == b(1); }), pts.end());
+    std::sort(pts.begin(), pts.end(), [](const Point& a, const Point& b) { return a(0) < b(0) || (a(0) == b(0) && a(1) < b(1)); });
+    pts.erase(std::unique(pts.begin(), pts.end(), [](const Point& a, const Point& b) { return a(0) == b(0) && a(1) == b(1); }), pts.end());
 
     Polygon hull;
     int n = (int)pts.size();
@@ -1291,11 +1291,11 @@ void ModelObject::split(ModelObjectPtrs* new_objects)
         
         // XXX: this seems to be the only real usage of m_model, maybe refactor this so that it's not needed?
         ModelObject* new_object = m_model->add_object();    
-		new_object->name   = this->name;
-		new_object->config = this->config;
-		new_object->instances.reserve(this->instances.size());
-		for (const ModelInstance *model_instance : this->instances)
-			new_object->add_instance(*model_instance);
+        new_object->name   = this->name;
+        new_object->config = this->config;
+        new_object->instances.reserve(this->instances.size());
+        for (const ModelInstance *model_instance : this->instances)
+            new_object->add_instance(*model_instance);
         ModelVolume* new_vol = new_object->add_volume(*volume, std::move(*mesh));
 #if !ENABLE_VOLUMES_CENTERING_FIXES
         new_vol->center_geometry();
@@ -1467,9 +1467,9 @@ int ModelVolume::extruder_id() const
 
 bool ModelVolume::is_splittable() const
 {
-    // the call mesh.has_multiple_patches() is expensive, so cache the value to calculate it only once
+    // the call mesh.is_splittable() is expensive, so cache the value to calculate it only once
     if (m_is_splittable == -1)
-        m_is_splittable = (int)mesh.has_multiple_patches();
+        m_is_splittable = (int)mesh.is_splittable();
 
     return m_is_splittable == 1;
 }

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1609,6 +1609,7 @@ void ModelVolume::rotate(double angle, Axis axis)
     case X: { rotate(angle, Vec3d::UnitX()); break; }
     case Y: { rotate(angle, Vec3d::UnitY()); break; }
     case Z: { rotate(angle, Vec3d::UnitZ()); break; }
+    default: break;
     }
 }
 
@@ -1625,6 +1626,7 @@ void ModelVolume::mirror(Axis axis)
     case X: { mirror(0) *= -1.0; break; }
     case Y: { mirror(1) *= -1.0; break; }
     case Z: { mirror(2) *= -1.0; break; }
+    default: break;
     }
     set_mirror(mirror);
 }
@@ -1711,7 +1713,6 @@ bool model_object_list_extended(const Model &model_old, const Model &model_new)
 
 bool model_volume_list_changed(const ModelObject &model_object_old, const ModelObject &model_object_new, const ModelVolumeType type)
 {
-    bool modifiers_differ = false;
     size_t i_old, i_new;
     for (i_old = 0, i_new = 0; i_old < model_object_old.volumes.size() && i_new < model_object_new.volumes.size();) {
         const ModelVolume &mv_old = *model_object_old.volumes[i_old];

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -420,12 +420,6 @@ private:
     TriangleMesh             m_convex_hull;
     Geometry::Transformation m_transformation;
 
-    // flag to optimize the checking if the volume is splittable
-    //     -1   ->   is unknown value (before first cheking)
-    //      0   ->   is not splittable
-    //      1   ->   is splittable
-    mutable int               m_is_splittable{ -1 };
-
 	ModelVolume(ModelObject *object, const TriangleMesh &mesh) : mesh(mesh), m_type(ModelVolumeType::MODEL_PART), object(object)
     {
         if (mesh.stl.stats.number_of_facets > 1)

--- a/src/libslic3r/TriangleMesh.cpp
+++ b/src/libslic3r/TriangleMesh.cpp
@@ -339,19 +339,6 @@ void TriangleMesh::rotate(double angle, Point* center)
 }
 
 /**
- * Calculates whether or not the mesh is splittable.
- */
-bool TriangleMesh::is_splittable() const
-{
-    std::vector<bool> visited;
-    find_unvisited_neighbors(visited);
-
-    // Try finding an unvisited facet. If there are none, the mesh is not splittable.
-    auto it = std::find(visited.begin(), visited.end(), false);
-    return it != visited.end();
-}
-
-/**
  * Visit all unvisited neighboring facets that are reachable from the first unvisited facet,
  * and return them.
  * 

--- a/src/libslic3r/TriangleMesh.cpp
+++ b/src/libslic3r/TriangleMesh.cpp
@@ -361,6 +361,10 @@ bool TriangleMesh::is_splittable() const
  */
 std::deque<uint32_t> TriangleMesh::find_unvisited_neighbors(std::vector<bool> &facet_visited) const
 {
+    // Make sure we're not operating on a broken mesh.
+    if (!this->repaired)
+        throw std::runtime_error("split() requires repair()");
+
     // If the visited list is empty, populate it with false for every facet.
     if (facet_visited.empty()) {
         facet_visited = std::vector<bool>(this->stl.stats.number_of_facets, false);
@@ -397,10 +401,6 @@ std::deque<uint32_t> TriangleMesh::find_unvisited_neighbors(std::vector<bool> &f
  */
 TriangleMeshPtrs TriangleMesh::split() const
 {
-    // Make sure we're not operating on a broken mesh.
-    if (!this->repaired)
-        throw std::runtime_error("split() requires repair()");
-    
     // Loop while we have remaining facets.
     std::vector<bool> facet_visited;
     TriangleMeshPtrs meshes;
@@ -417,7 +417,7 @@ TriangleMeshPtrs TriangleMesh::split() const
         mesh->stl.stats.original_num_facets = mesh->stl.stats.number_of_facets;
         stl_clear_error(&mesh->stl);
         stl_allocate(&mesh->stl);
-        
+
         // Assign the facets to the new mesh.
         bool first = true;
         for (auto facet = facets.begin(); facet != facets.end(); ++ facet) {
@@ -425,7 +425,7 @@ TriangleMeshPtrs TriangleMesh::split() const
             stl_facet_stats(&mesh->stl, this->stl.facet_start[*facet], first);
         }
     }
-    
+
     return meshes;
 }
 

--- a/src/libslic3r/TriangleMesh.hpp
+++ b/src/libslic3r/TriangleMesh.hpp
@@ -68,7 +68,6 @@ public:
     size_t facets_count() const { return this->stl.stats.number_of_facets; }
     bool   empty() const { return this->facets_count() == 0; }
 
-    bool is_splittable() const;
     std::deque<uint32_t> find_unvisited_neighbors(std::vector<bool> &facet_visited) const;
 
     stl_file stl;

--- a/src/libslic3r/TriangleMesh.hpp
+++ b/src/libslic3r/TriangleMesh.hpp
@@ -68,12 +68,8 @@ public:
     size_t facets_count() const { return this->stl.stats.number_of_facets; }
     bool   empty() const { return this->facets_count() == 0; }
 
-    // Returns true, if there are two and more connected patches in the mesh.
-    // Returns false, if one or zero connected patch is in the mesh.
-    bool has_multiple_patches() const;
-
-    // Count disconnected triangle patches.
-    size_t number_of_patches() const;
+    bool is_splittable() const;
+    std::deque<uint32_t> find_unvisited_neighbors(std::vector<bool> &facet_visited) const;
 
     stl_file stl;
     bool repaired;

--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -208,7 +208,7 @@ public:
 
 // Shorten the dhms time by removing the seconds, rounding the dhm to full minutes
 // and removing spaces.
-static std::string short_time(const std::string &time)
+inline std::string short_time(const std::string &time)
 {
     // Parse the dhms time format.
     int days = 0;
@@ -247,7 +247,7 @@ static std::string short_time(const std::string &time)
 }
 
 // Returns the given time is seconds in format DDd HHh MMm SSs
-static std::string get_time_dhms(float time_in_secs)
+inline std::string get_time_dhms(float time_in_secs)
 {
     int days = (int)(time_in_secs / 86400.0f);
     time_in_secs -= (float)days * 86400.0f;


### PR DESCRIPTION
There was a bunch of duplicate and dead code related to splitting models, so I cleaned up the duplicate code and removed the dead code.

I also fixed some warnings in the related files while I was at it, so errors would not get drowned in the build output.

Fixes #1989 