### PR TITLE
don't use features from unstable WX versions

### DIFF
--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -2352,9 +2352,8 @@ void ModeButton::SetState(const bool state)
 void ModeButton::focus_button(const bool focus)
 {
     wxFont font = GetFont();
-    const wxFont& new_font = focus ? font.Bold() : font.GetBaseFont();
-
-    SetFont(new_font);
+    font.SetWeight(focus ? wxFONTWEIGHT_BOLD : wxFONTWEIGHT_NORMAL);
+    SetFont(font);
 
     Refresh();
     Update();


### PR DESCRIPTION
This resolves build issue #2168 by removing the usage of a WX 3.1 function introduced by @YuSanka. 